### PR TITLE
Refactor documentation for conciseness and duplication

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -99,6 +99,8 @@ This file provides operational instructions for AI coding agents working in this
 
 ## API endpoints
 
+Full request/response details: [docs/ARCHITECTURE.md](docs/ARCHITECTURE.md).
+
 - **GET /api/events** - List events
   - Query params: `startDate` (timestamp), `endDate` (timestamp), `limit` (default 50, max 200)
   - Returns: Array of event objects with `stats` object; optional `srcFileType` when present
@@ -131,22 +133,13 @@ This file provides operational instructions for AI coding agents working in this
 - **Relational stats storage:** Event and activity statistics stored in separate tables (`event_stats`, `activity_stats`) with one row per stat type, not as JSON blobs.
 - **Timestamped stream data:** Stream data stored relationally in `stream_data_points` with `time_ms` (BIGINT UTC milliseconds) and `sequence_index` for ordering.
 - **No migrations:** Schema runs on startup via `initializeSchema()`. Schema changes require recreating database.
-- **Self-hosted deployment:** Docker Compose is the deployment artifact. No cloud dependencies.
+- **Self-hosted deployment:** Docker Compose is the deployment artifact. No cloud dependencies. Rationale in [docs/ARCHITECTURE.md](docs/ARCHITECTURE.md).
 
 ## Conventions (coding, naming, error handling)
 
-- **Svelte (frontend):**
-  - Svelte 5 runes (`$state`, `$derived`, `$effect`); component props via `$props()`
-  - Tailwind CSS v4 for all styling; no SCSS or component CSS files
-  - API calls via `fetch()` in plain `.ts` modules; no RxJS
+- **Svelte (frontend):** Svelte 5 runes and Tailwind only. See [.cursor/rules/svelte-frontend.mdc](.cursor/rules/svelte-frontend.mdc).
 
-- **JavaScript (backend):**
-  - Node.js 24+ with CommonJS modules
-  - Express.js for HTTP server
-  - MySQL2 with connection pooling
-  - No TypeScript in backend (plain JavaScript)
-  - **Repositories own SQL**: `backend/src/repositories/` (event-repository, activity-repository, stream-repository, comparison-repository) contain all SQL. Services call repositories and pass `opts.db` or `opts.conn` (inside transactions). Use `runQuery(sql, params, opts)` in repositories; do not use `db.getPool().execute()` in services.
-  - All services that touch the DB accept optional `opts.db` for test injection. See `backend/README.md` for module map and conventions.
+- **JavaScript (backend):** Backend: repositories own SQL; services accept `opts.db` and use transactions for multi-statement writes; routes are thin. See [backend/README.md](backend/README.md) for module map and [.cursor/rules/backend-architecture.mdc](.cursor/rules/backend-architecture.mdc) for full conventions.
 
 - **Database:**
   - MariaDB/MySQL compatible
@@ -208,19 +201,33 @@ This file provides operational instructions for AI coding agents working in this
   - `MARIADB_USER` - Database user (default: qs)
   - `MARIADB_PASSWORD` - Database password (default: qspass)
 
+## Smoke test (after refactors)
+
+Run this checklist after each refactoring stage to confirm the app still works.
+
+1. **Upload a .FIT file via dashboard** → Verify event appears in the list.
+2. **Click event** → Verify detail page loads with stats + charts.
+3. **Navigate to comparisons** → Verify list loads.
+4. **DELETE an event** → Verify removal (event disappears from list).
+5. **Filter by activity type on dashboard** → Verify filtering works.
+
 ## When unsure (how to confirm unknowns; which files to read)
 
-- **Backend structure and conventions:** Check `backend/README.md`
-- **API endpoints:** Check `backend/src/routes/events.js`
-- **Database schema:** Check `backend/sql/schema.sql`
-- **File parsing:** Check `backend/src/parsers/file-parser.js`
-- **Stream extraction:** Check `backend/src/utils/stream-extractor.js`
-- **Database connection:** Check `backend/src/db.js`
-- **Frontend API and types:** Check `frontend/src/lib/api/`, `frontend/src/lib/types/`
-- **Frontend routes/pages:** Check `frontend/src/routes/`
-- **Route map (GPS):** Check `frontend/src/lib/components/RouteMap.svelte`, `frontend/src/lib/utils/geo.ts`
-- **Docker setup:** Check `docker-compose.yaml`
-- **Package scripts:** Check `backend/package.json` and `frontend/package.json`
-- **Frontend build:** Check `frontend/vite.config.ts`
-- **Cloud hosting (AWS/GCP):** Check `docs/HOSTING.md`
-- **Unknown:** Read relevant source files before making assumptions
+| Topic | File(s) |
+|-------|---------|
+| API endpoints | `backend/src/routes/events.js`; full details [docs/ARCHITECTURE.md](docs/ARCHITECTURE.md) |
+| Database schema | `backend/sql/schema.sql` |
+| Backend conventions | `backend/README.md`, `.cursor/rules/backend-architecture.mdc` |
+| Frontend conventions | `.cursor/rules/svelte-frontend.mdc` |
+| Frontend API and types | `frontend/src/lib/api/`, `frontend/src/lib/types/` |
+| Frontend routes/pages | `frontend/src/routes/` |
+| Route map (GPS) | `frontend/src/lib/components/RouteMap.svelte`, `frontend/src/lib/utils/geo.ts` |
+| File parsing | `backend/src/parsers/file-parser.js` |
+| Stream extraction | `backend/src/utils/stream-extractor.js` |
+| Database connection | `backend/src/db.js` |
+| Docker setup | `docker-compose.yaml` |
+| Package scripts | `backend/package.json`, `frontend/package.json` |
+| Frontend build | `frontend/vite.config.ts` |
+| Cloud hosting (AWS/GCP) | `docs/HOSTING.md` |
+
+Read relevant source files before making assumptions.

--- a/README.md
+++ b/README.md
@@ -77,30 +77,7 @@ Edit files under `backend/` or `frontend/` on your host and changes are reflecte
 
 ## API Documentation
 
-### Events API
-
-- **GET /api/events** – List events
-  - Query params: `startDate`, `endDate` (timestamps), `limit` (default 50, max 200)
-  - Returns: Array of event objects with `stats` (and optional `srcFileType`)
-
-- **GET /api/events/:id** – Get single event with activities
-  - Returns: `{ event: {...}, activities: [...] }`
-  - Event and activities include `stats` objects
-
-- **GET /api/events/:id/activities/:activityId/streams** – Get stream data
-  - Query params: `types` (optional, filter by stream types)
-  - Returns: Array of `{ type: string, data: [{ time: number, value: any }, ...] }`
-
-- **POST /api/events** – Upload and parse file
-  - Content-Type: `multipart/form-data`
-  - Body: `files` (one or more files: TCX, FIT, GPX, JSON, SML)
-  - Backend parses file, extracts event/activities/streams, stores in database
-  - Files are parsed and discarded (not stored)
-  - Returns: `{ id: string, event: {...}, activities: [...] }`
-
-- **DELETE /api/events/:id** – Delete event
-  - Cascades to delete all related data (stats, streams, activities)
-  - Returns: 204 No Content or 404 Not Found
+Events API: **GET** `/api/events` (list), **GET** `/api/events/:id` (single + activities), **GET** `/api/events/:id/activities/:activityId/streams` (streams), **POST** `/api/events` (upload), **DELETE** `/api/events/:id` (delete). See [docs/ARCHITECTURE.md](docs/ARCHITECTURE.md) for parameters and response shapes.
 
 ## Production Build
 
@@ -137,8 +114,4 @@ Data in MariaDB is kept in the `db_data` volume. Use `docker compose down -v` to
 
 ## Key Architectural Decisions
 
-- **File parsing on backend**: Files are uploaded raw, parsed server-side, then discarded. No file storage.
-- **Relational stats storage**: Statistics stored in separate tables (`event_stats`, `activity_stats`) with one row per stat type.
-- **Timestamped stream data**: Stream data stored relationally in `stream_data_points` with `time_ms` (UTC milliseconds).
-- **No migrations**: Schema runs on startup. Schema changes require recreating database.
-- **Self-hosted deployment**: Docker Compose is the deployment artifact.
+Key decisions (file parsing on backend, relational stats storage, timestamped stream data, no migrations, self-hosted deployment) are documented in [docs/ARCHITECTURE.md](docs/ARCHITECTURE.md).

--- a/backend/README.md
+++ b/backend/README.md
@@ -15,8 +15,7 @@ Node.js Express API for OpenFitLab. See [AGENTS.md](../AGENTS.md) at project roo
 
 ## Data access
 
-- All SQL lives in **repositories**. Services call repositories and pass `opts` (with `opts.db` or, inside `db.transaction(fn)`, `opts.conn`). Repositories use `runQuery(sql, params, opts)` which uses `conn.execute` when `opts.conn` is set, else `db.query`.
-- For unit tests, inject a fake `db` with `query` (and where needed `transaction`); repositories receive `opts.db` from the service.
+SQL in repositories only; services pass `opts.db` or `opts.conn` (inside transactions). See [.cursor/rules/backend-architecture.mdc](../.cursor/rules/backend-architecture.mdc) for full conventions (transactions, routes, testing).
 
 ## Errors
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -108,6 +108,8 @@ All relationships use foreign keys with **ON DELETE CASCADE**: deleting an event
 
 ### Event vs Activity: Core Concepts
 
+Product definitions: [docs/PRD.md](docs/PRD.md) §10.1 Glossary. Below: technical implementation (tables, relationships).
+
 Understanding the distinction between **Events** and **Activities** is fundamental to the data model:
 
 #### Event
@@ -431,56 +433,32 @@ frontend/src/
 ### 1. File Parsing on Backend
 **Decision**: Parse files server-side, not client-side.
 
-**Rationale**:
-- Consistent parsing logic across clients
-- Better error handling and validation
-- Can handle large files without browser memory issues
-- Files are parsed and discarded (no storage needed)
+**Rationale**: Consistent parsing and validation; handles large files without browser limits. Files are parsed and discarded (no storage).
 
 ### 2. Relational Stats Storage
 **Decision**: Store statistics in separate tables (`event_stats`, `activity_stats`) with one row per stat type.
 
-**Rationale**:
-- Enables efficient querying by stat type
-- Allows indexing on stat types
-- Easier to add new stat types without schema changes
-- Better than JSON blobs for querying
+**Rationale**: Enables efficient querying and indexing by stat type; easier to extend than JSON blobs.
 
 ### 3. Timestamped Stream Data Points
 **Decision**: Store stream data points relationally with `time_ms` (BIGINT) timestamps.
 
-**Rationale**:
-- Efficient time-range queries
-- Can index on time for fast filtering
-- Enables time-based comparisons between streams
-- Better than storing entire arrays as JSON
+**Rationale**: Efficient time-range queries and indexing; enables time-based comparisons; better than JSON arrays.
 
 ### 4. No File Storage
 **Decision**: Parse files and discard them, don't store originals.
 
-**Rationale**:
-- Reduces storage requirements
-- All data is in database (can regenerate visualizations)
-- Simpler architecture (no file management)
-- Users can re-upload if needed
+**Rationale**: Reduces storage; all data in DB for regeneration; simpler architecture; users can re-upload.
 
 ### 5. No Database Migrations
 **Decision**: Schema runs on startup via `initializeSchema()`, no migration system.
 
-**Rationale**:
-- Simpler for self-hosted deployment
-- Schema changes require recreating database (acceptable for self-hosted)
-- Avoids migration complexity
-- Clear schema versioning via `schema.sql`
+**Rationale**: Simpler for self-hosted; schema changes require DB recreate (acceptable); clear versioning via `schema.sql`.
 
 ### 6. Self-Hosted Deployment
 **Decision**: Docker Compose is the deployment artifact.
 
-**Rationale**:
-- User owns their data
-- No cloud dependencies
-- Simple deployment (one command)
-- Can run on any host with Docker
+**Rationale**: User owns data; no cloud lock-in; one-command deployment on any host with Docker.
 
 ## Deployment options
 

--- a/docs/PRD.md
+++ b/docs/PRD.md
@@ -400,6 +400,9 @@ Provide a privacy-focused, self-hosted solution for fitness enthusiasts to uploa
 ## 10. Appendices
 
 ### 10.1 Glossary
+
+These terms define the product; technical implementation (tables, API) is in [docs/ARCHITECTURE.md](docs/ARCHITECTURE.md).
+
 - **Event**: A top-level workout session created from a single file upload. An event can contain one or more activities and has event-level statistics aggregated across all its activities. The event name is typically derived from the uploaded filename.
 
 - **Activity**: An individual sport segment within an event. Each activity has a sport type (Running, Cycling, Swimming, etc.), its own statistics, and owns all time-series stream data (heart rate, GPS, cadence, etc.). Most single-sport files create one event with one activity, while multi-sport files (e.g., triathlons) create one event with multiple activities.

--- a/docs/SMOKE-TEST.md
+++ b/docs/SMOKE-TEST.md
@@ -1,9 +1,0 @@
-# Smoke test checklist
-
-Run this checklist after each refactoring stage to confirm the app still works.
-
-1. **Upload a .FIT file via dashboard** → Verify event appears in the list.
-2. **Click event** → Verify detail page loads with stats + charts.
-3. **Navigate to comparisons** → Verify list loads.
-4. **DELETE an event** → Verify removal (event disappears from list).
-5. **Filter by activity type on dashboard** → Verify filtering works.

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -1,47 +1,5 @@
-# Svelte + TS + Vite
+# OpenFitLab Frontend
 
-This template should help get you started developing with Svelte and TypeScript in Vite.
+Svelte 5, Vite, Tailwind CSS v4, svelte-spa-router. Run: `npm run dev`. Build: `npm run build`; preview: `npm run preview`. The app uses `/api` for the backend (proxied in dev, same-origin in production).
 
-## Recommended IDE Setup
-
-[VS Code](https://code.visualstudio.com/) + [Svelte](https://marketplace.visualstudio.com/items?itemName=svelte.svelte-vscode).
-
-## Need an official Svelte framework?
-
-Check out [SvelteKit](https://github.com/sveltejs/kit#readme), which is also powered by Vite. Deploy anywhere with its serverless-first approach and adapt to various platforms, with out of the box support for TypeScript, SCSS, and Less, and easily-added support for mdsvex, GraphQL, PostCSS, Tailwind CSS, and more.
-
-## Technical considerations
-
-**Why use this over SvelteKit?**
-
-- It brings its own routing solution which might not be preferable for some users.
-- It is first and foremost a framework that just happens to use Vite under the hood, not a Vite app.
-
-This template contains as little as possible to get started with Vite + TypeScript + Svelte, while taking into account the developer experience with regards to HMR and intellisense. It demonstrates capabilities on par with the other `create-vite` templates and is a good starting point for beginners dipping their toes into a Vite + Svelte project.
-
-Should you later need the extended capabilities and extensibility provided by SvelteKit, the template has been structured similarly to SvelteKit so that it is easy to migrate.
-
-**Why `global.d.ts` instead of `compilerOptions.types` inside `jsconfig.json` or `tsconfig.json`?**
-
-Setting `compilerOptions.types` shuts out all other types not explicitly listed in the configuration. Using triple-slash references keeps the default TypeScript setting of accepting type information from the entire workspace, while also adding `svelte` and `vite/client` type information.
-
-**Why include `.vscode/extensions.json`?**
-
-Other templates indirectly recommend extensions via the README, but this file allows VS Code to prompt the user to install the recommended extension upon opening the project.
-
-**Why enable `allowJs` in the TS template?**
-
-While `allowJs: false` would indeed prevent the use of `.js` files in the project, it does not prevent the use of JavaScript syntax in `.svelte` files. In addition, it would force `checkJs: false`, bringing the worst of both worlds: not being able to guarantee the entire codebase is TypeScript, and also having worse typechecking for the existing JavaScript. In addition, there are valid use cases in which a mixed codebase may be relevant.
-
-**Why is HMR not preserving my local component state?**
-
-HMR state preservation comes with a number of gotchas! It has been disabled by default in both `svelte-hmr` and `@sveltejs/vite-plugin-svelte` due to its often surprising behavior. You can read the details [here](https://github.com/rixo/svelte-hmr#svelte-hmr).
-
-If you have state that's important to retain within a component, consider creating an external store which would not be replaced by HMR.
-
-```ts
-// store.ts
-// An extremely simple external store
-import { writable } from 'svelte/store'
-export default writable(0)
-```
+See root [AGENTS.md](../AGENTS.md) for stack and [.cursor/rules/svelte-frontend.mdc](../.cursor/rules/svelte-frontend.mdc) for conventions.


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Docs-only changes (content moves and link updates) with no runtime, API, or schema modifications.
> 
> **Overview**
> Documentation is refactored to be more concise and less repetitive by **centralizing details in `docs/ARCHITECTURE.md`** and converting long duplicated sections into short link-outs.
> 
> `AGENTS.md`, root `README.md`, and `backend/README.md` are updated to reference the architecture and Cursor rule docs for full conventions; `frontend/README.md` is simplified to a short project-specific overview. The standalone `docs/SMOKE-TEST.md` checklist is removed and its content is moved into `AGENTS.md`, along with a new “when unsure” lookup table.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 60809d61e14454e735dde4f9ee54d31b394f2978. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->