### PR TITLE
Tighten up node 24 on backend

### DIFF
--- a/.github/workflows/backend-checks.yml
+++ b/.github/workflows/backend-checks.yml
@@ -40,3 +40,8 @@ jobs:
 
       - name: Unit tests
         run: npm run test:unit
+
+      - name: Unit tests (no deprecations)
+        run: npm run test:unit
+        env:
+          NODE_OPTIONS: '--throw-deprecation'

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -41,6 +41,7 @@ This file provides operational instructions for AI coding agents working in this
   - `npm run format:fix` - Fix formatting
   - `npm run test` - Run all tests (Node test runner)
   - `npm run test:unit` - Run unit tests only (`test/unit/**/*.test.js`)
+  - To verify Node 24 compatibility, run tests with `NODE_OPTIONS='--throw-deprecation' npm run test:unit` so deprecations fail the build.
 
 ### Frontend (`frontend/`)
 

--- a/backend/src/index.js
+++ b/backend/src/index.js
@@ -46,7 +46,11 @@ app.use((err, req, res, next) => {
 });
 
 async function start() {
-  if (!fs.existsSync(UPLOAD_DIR)) fs.mkdirSync(UPLOAD_DIR, { recursive: true });
+  const uploadDir =
+    typeof UPLOAD_DIR === 'string' && UPLOAD_DIR.trim().length > 0
+      ? UPLOAD_DIR.trim()
+      : path.join(__dirname, '..', 'uploads');
+  if (!fs.existsSync(uploadDir)) fs.mkdirSync(uploadDir, { recursive: true });
   await db.initializeSchema();
   app.listen(PORT, '0.0.0.0', () => {
     console.log(`API listening on http://0.0.0.0:${PORT}`);


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk: adds stricter CI test mode and a small startup guard around `UPLOAD_DIR` handling; minimal behavior change aside from safer default directory selection.
> 
> **Overview**
> Tightens Node 24 backend checks by running unit tests a second time in CI with `NODE_OPTIONS='--throw-deprecation'`, causing deprecation warnings to fail the build.
> 
> Hardens backend startup by sanitizing `UPLOAD_DIR` (trimming and treating empty/whitespace as unset) and falling back to `backend/uploads` before ensuring the directory exists; updates `AGENTS.md` with the same Node 24 deprecation-test guidance.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 16ac58abdec6bf17c773103ad0540de28d94aea7. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->