### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/frontend-checks.yml
+++ b/.github/workflows/frontend-checks.yml
@@ -1,5 +1,8 @@
 name: Frontend checks
 
+permissions:
+  contents: read
+
 on:
   push:
     branches: [main]


### PR DESCRIPTION
Potential fix for [https://github.com/luispabon/OpenFitLab/security/code-scanning/2](https://github.com/luispabon/OpenFitLab/security/code-scanning/2)

In general, the fix is to add an explicit `permissions` block to the workflow (or to the specific job) that grants only the minimal required access to the `GITHUB_TOKEN`. Since this workflow only reads repository contents (via `actions/checkout`) and performs local Node/npm commands, it only needs read access to the repository contents.

The best fix here is to add a root-level `permissions` block right after the `name` field in `.github/workflows/frontend-checks.yml`, setting `contents: read`. This will apply to all jobs in this workflow (currently just `lint-format-test`) and will not alter any behavior, because these jobs do not rely on write permissions. No imports, methods, or additional definitions are needed since this is purely a YAML configuration change within the workflow file.

Concretely:
- Edit `.github/workflows/frontend-checks.yml`.
- Insert:

  ```yaml
  permissions:
    contents: read
  ```

  between the existing `name: Frontend checks` line and the `on:` block. No other lines need to be changed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
