### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/backend-checks.yml
+++ b/.github/workflows/backend-checks.yml
@@ -1,5 +1,8 @@
 name: Backend checks
 
+permissions:
+  contents: read
+
 on:
   push:
     branches: [main]


### PR DESCRIPTION
Potential fix for [https://github.com/luispabon/OpenFitLab/security/code-scanning/1](https://github.com/luispabon/OpenFitLab/security/code-scanning/1)

In general, the fix is to explicitly declare a `permissions` block that limits the GITHUB_TOKEN to the minimum scopes needed. Since this workflow only checks out code and runs local Node commands (linting, testing, coverage), it only needs read access to repository contents. The standard minimal permissions for such workflows are `contents: read`.

The single best way to fix this without changing behavior is to add a workflow-level `permissions` block near the top of `.github/workflows/backend-checks.yml`, alongside `name` and `on`. That way, the setting applies to all jobs in this workflow, including `lint-format-test`, and no job-level overrides are needed. Concretely, insert:

```yaml
permissions:
  contents: read
```

between the `name: Backend checks` line and the `on:` block (or just above `jobs:` if you prefer the alternative placement), preserving indentation. No imports, methods, or additional definitions are required; the change is purely declarative in the YAML.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
