### PR TITLE
Potential fix for code scanning alert no. 3: Missing CSRF middleware

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -31,7 +31,8 @@
     "passport": "^0.7.0",
     "passport-github2": "^0.1.12",
     "passport-google-oauth20": "^2.0.0",
-    "@xmldom/xmldom": "^0.9.0"
+    "@xmldom/xmldom": "^0.9.0",
+    "csurf": "^1.11.0"
   },
   "devDependencies": {
     "@eslint/js": "^10.0.1",

--- a/backend/src/middleware/session.js
+++ b/backend/src/middleware/session.js
@@ -1,11 +1,12 @@
 const session = require('express-session');
 const MySQLStore = require('express-mysql-session')(session);
 const config = require('../config');
+const csrf = require('csurf');
 
 /**
  * Creates the session middleware backed by the existing MariaDB pool.
  * @param {object} pool - mysql2/promise pool instance
- * @returns {function} Express session middleware
+ * @returns {function} Express session + CSRF middleware
  */
 function createSessionMiddleware(pool) {
   const store = new MySQLStore(
@@ -24,7 +25,7 @@ function createSessionMiddleware(pool) {
   );
 
   // secure and maxAge set; domain omitted by design (same-origin). See AGENTS.md Security.
-  return session({
+  const sessionMiddleware = session({
     secret: config.session.secret,
     store,
     resave: false,
@@ -38,6 +39,18 @@ function createSessionMiddleware(pool) {
       path: '/',
     },
   });
+
+  const csrfMiddleware = csrf();
+
+  // Ensure that CSRF checks run after the session has been established.
+  return function sessionWithCsrf(req, res, next) {
+    sessionMiddleware(req, res, function sessionNext(err) {
+      if (err) {
+        return next(err);
+      }
+      csrfMiddleware(req, res, next);
+    });
+  };
 }
 
 module.exports = { createSessionMiddleware };


### PR DESCRIPTION
Potential fix for [https://github.com/luispabon/OpenFitLab/security/code-scanning/3](https://github.com/luispabon/OpenFitLab/security/code-scanning/3)

In general, the fix is to ensure that any state-changing request that relies on this session cookie is also protected by a CSRF mechanism. In Express, this is typically done by adding a CSRF middleware like `csurf` (or `lusca.csrf`) after sessions are configured, and then ensuring clients send the CSRF token with each unsafe request. Since this file only creates the session middleware, the best we can do *within this snippet* is to augment the exported middleware so that any caller using `createSessionMiddleware(pool)` automatically gets CSRF protection as well.

The most straightforward, low-impact change here is:

1. Import a well-known CSRF middleware (e.g. `csurf`).
2. In `createSessionMiddleware(pool)`, keep the existing session configuration unchanged.
3. Create a small stack of middlewares that runs the session first, then CSRF, and export that combined middleware instead of only the session. This preserves existing session behavior while adding CSRF protection wherever this middleware is used.
4. Because we can’t see the router code, we’ll implement the generic CSRF middleware without assuming how tokens are exposed to templates/clients; those integration details must be addressed in the calling code (for example by reading `req.csrfToken()` in route handlers and sending it to the client). Our change simply ensures a CSRF check is in place.

Concretely in `backend/src/middleware/session.js`:

- Add `const csrf = require('csurf');` at the top.
- In `createSessionMiddleware(pool)`, keep constructing `store` as-is.
- Replace the direct `return session({ ... })` with:
  - `const sessionMiddleware = session({ ... });`
  - `const csrfMiddleware = csrf();`
  - `return function sessionWithCsrf(req, res, next) { sessionMiddleware(req, res, function (err) { if (err) return next(err); csrfMiddleware(req, res, next); }); };`

This ensures that any route using this exported middleware will have sessions and CSRF protection active, addressing all of the CodeQL variants that complain about missing CSRF protection behind this cookie middleware.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
