### PR TITLE
Preserve event order in comparisons so "Find" event is principal

### DIFF
--- a/frontend/src/lib/utils/comparison-loader.svelte.ts
+++ b/frontend/src/lib/utils/comparison-loader.svelte.ts
@@ -65,7 +65,8 @@ export function reset(): void {
 
 function deriveKey(comparisonId: string, eventIdsFromQuery: string[]): string {
   if (comparisonId === 'new') {
-    const ids = eventIdsFromQuery.filter((id) => id.trim().length > 0).sort();
+    // Preserve URL order so the first event is the "principal" (e.g. from Find on dashboard).
+    const ids = eventIdsFromQuery.filter((id) => id.trim().length > 0);
     return ids.length >= 2 ? `new:${ids.join(',')}` : '';
   }
   return comparisonId;
@@ -173,7 +174,8 @@ export function load(comparisonId: string, eventIdsFromQuery: string[]): void {
   const signal = abortController.signal;
 
   if (comparisonId === 'new') {
-    const ids = eventIdsFromQuery.filter((id) => id.trim().length > 0).sort();
+    // Use URL order: first event is principal (from "Find" on dashboard).
+    const ids = eventIdsFromQuery.filter((id) => id.trim().length > 0);
     if (ids.length < 2) {
       state.error = 'At least 2 events are required for comparison';
       state.status = 'error';


### PR DESCRIPTION
When opening a comparison from the dashboard via "Find", the clicked event is now always first (principal). Remove sorting of event IDs in the comparison loader so URL order is kept: first column and first chart color match the event the user started from.