### PR TITLE
feat: optimise database schema for activity comparisons and various fixes

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -128,10 +128,10 @@ On **push to main** and **pull_request** targeting main:
   - `activity_stats` - Activity-level statistics (activity_id, stat_type, value JSON)
   - `streams` - Stream metadata (id, activity_id, event_id, type)
   - `stream_data_points` - Timestamped stream data (id, stream_id, time_ms BIGINT, value JSON, sequence_index)
-  - `comparisons` - Saved comparison definitions (id, user_id, name, settings JSON, created_at). Event membership is in `comparison_events`. FK to users ON DELETE CASCADE.
-  - `comparison_events` - Link table (comparison_id, event_id) with FK to comparisons ON DELETE CASCADE and FK to events ON DELETE CASCADE. Event IDs for a comparison are stored here, not as JSON.
-  - Foreign keys with ON DELETE CASCADE: user_identities → users; event_stats → events; activities → events; activity_stats → activities; streams → activities, events; stream_data_points → streams; comparison_events → comparisons, events; events → users; comparisons → users. Deleting a user cascades to identities, events (and their stats, activities, streams, stream_data_points), and comparisons (and comparison_events). Deleting an event: event-delete-service deletes comparisons that reference it (in a transaction), then deletes the event; CASCADE removes related rows.
-  - Indexes: foreign keys; users (id); user_identities (user_id, uk_provider_identity); sessions (expires); events (user_id, start_date, idx_user_start_date); activities (event_id, type, device_name, start_date); stream_data_points (stream_id, time_ms; stream_id, sequence_index, time_ms); comparisons (user_id, created_at); comparison_events (event_id).
+  - `comparisons` - Saved comparison definitions (id, user_id, name, settings JSON, created_at). Per-event activity membership is in `comparison_event_activities`. FK to users ON DELETE CASCADE.
+  - `comparison_event_activities` - Link table (comparison_id, event_id, activity_id) with FK to comparisons, events, and activities ON DELETE CASCADE. Each comparison can reference one activity per event (PK is (comparison_id, event_id)).
+  - Foreign keys with ON DELETE CASCADE: user_identities → users; event_stats → events; activities → events; activity_stats → activities; streams → activities, events; stream_data_points → streams; comparison_event_activities → comparisons, events, activities; events → users; comparisons → users. Deleting a user cascades to identities, events (and their stats, activities, streams, stream_data_points), and comparisons (and comparison_event_activities). Deleting an event: event-delete-service deletes comparisons that reference it (in a transaction), then deletes the event; CASCADE removes related rows.
+  - Indexes: foreign keys; users (id); user_identities (user_id, uk_provider_identity); sessions (expires); events (user_id, start_date, idx_user_start_date); activities (event_id, type, device_name, start_date); stream_data_points (stream_id, time_ms; stream_id, sequence_index, time_ms); comparisons (user_id, created_at); comparison_event_activities (event_id, activity_id).
   - Schema auto-initializes on API startup via `db.initializeSchema()`
 
 ## API endpoints
@@ -186,7 +186,7 @@ Full request/response details: [docs/ARCHITECTURE.md](docs/ARCHITECTURE.md).
   - Files are parsed and discarded (not stored)
 
 - **DELETE /api/events/:id** - Delete event
-  - In a transaction: deletes any comparisons that reference this event (via comparison_events), then deletes the event. Database ON DELETE CASCADE removes event_stats, activities, activity_stats, streams, stream_data_points, and comparison_events rows.
+- In a transaction: deletes any comparisons that reference this event (via comparison_event_activities), then deletes the event. Database ON DELETE CASCADE removes event_stats, activities, activity_stats, streams, stream_data_points, and comparison_event_activities rows.
   - Returns: 204 No Content or 404 Not Found
 
 - **GET /api/activity-types** - Distinct activity types from current user's activities (for filters/editors)
@@ -196,7 +196,7 @@ Full request/response details: [docs/ARCHITECTURE.md](docs/ARCHITECTURE.md).
   - Returns: Array of strings
 
 - **GET /api/comparisons** - List saved comparisons
-  - Returns: Array of `{ id, name, eventIds, settings?, createdAt? }` (createdAt in ms; eventIds from comparison_events)
+- Returns: Array of `{ id, name, eventIds, activityIds, settings?, createdAt? }` (createdAt in ms; eventIds/activityIds from `comparison_event_activities`).
 
 - **POST /api/comparisons/by-events** - Find comparisons linked to any of the given event IDs (e.g. for delete warnings)
   - Body: `{ eventIds: string[] }` (non-empty array of UUIDs)
@@ -232,8 +232,8 @@ Full request/response details: [docs/ARCHITECTURE.md](docs/ARCHITECTURE.md).
   - MariaDB/MySQL compatible
   - UUIDs stored as VARCHAR(36)
   - Timestamps stored as BIGINT (milliseconds since epoch)
-  - JSON columns for flexible data (`value` in event_stats/activity_stats; comparisons.settings). Comparison–event links are relational in `comparison_events`, not JSON.
-  - Foreign keys with ON DELETE CASCADE for event→event_stats, event→activities, activity→activity_stats, activity→streams, event→streams, stream→stream_data_points, comparison_events→comparisons and →events
+- JSON columns for flexible data (`value` in event_stats/activity_stats; comparisons.settings). Comparison–event/activity links are relational in `comparison_event_activities`, not JSON.
+- Foreign keys with ON DELETE CASCADE for event→event_stats, event→activities, activity→activity_stats, activity→streams, event→streams, stream→stream_data_points, comparison_event_activities→comparisons/events/activities
   - Indexes on foreign key columns and time ranges
 
 - **API responses:**
@@ -255,7 +255,7 @@ Full request/response details: [docs/ARCHITECTURE.md](docs/ARCHITECTURE.md).
   - Store original files after parsing (they should be discarded)
   - Change API response format without updating frontend
   - Break the relational stats structure (use `event_stats`/`activity_stats` tables, not JSON blobs)
-  - Store comparison event membership as JSON; use the `comparison_events` link table
+- Store comparison event/activity membership relationally; use the `comparison_event_activities` link table
   - Modify stream data structure without updating `stream-extractor.js` and API endpoints
   - Omit `user_id` (or `userId` in opts) from any query that reads or writes events or comparisons; every such query must scope by the authenticated user to prevent IDOR/data leak
   - Trust `user_id` or resource ownership from request body or URL params; use only `req.userId` from requireAuth middleware
@@ -268,7 +268,7 @@ Full request/response details: [docs/ARCHITECTURE.md](docs/ARCHITECTURE.md).
   - Use UUIDs for event/activity IDs (generated via `randomUUID()`)
   - Return stats nested under `stats` key in API responses
   - Handle JSON parsing for database JSON columns (may be objects or strings)
-  - When deleting an event: delete comparisons that reference it first (event-delete-service does this in a transaction), then delete the event; CASCADE removes related rows (event_stats, activities, streams, comparison_events, etc.)
+- When deleting an event: delete comparisons that reference it first (event-delete-service does this in a transaction), then delete the event; CASCADE removes related rows (event_stats, activities, streams, comparison_event_activities, etc.)
   - Pass `userId` from `req.userId` into all services/repositories that list, create, or access events or comparisons; enforce ownership (e.g. `WHERE user_id = ?`) so users only see their own data
   - Return 404 (not 403) when a resource by ID is not found or not owned, to avoid leaking existence
 

--- a/backend/sql/schema.sql
+++ b/backend/sql/schema.sql
@@ -142,13 +142,16 @@ CREATE TABLE IF NOT EXISTS comparisons (
 DEFAULT CHARSET = utf8mb4
 COLLATE = utf8mb4_unicode_ci;
 
-CREATE TABLE IF NOT EXISTS comparison_events (
+CREATE TABLE IF NOT EXISTS comparison_event_activities (
   comparison_id VARCHAR(36) NOT NULL,
   event_id VARCHAR(36) NOT NULL,
+  activity_id VARCHAR(36) NOT NULL,
   PRIMARY KEY (comparison_id, event_id),
   INDEX idx_event_id (event_id),
-  CONSTRAINT fk_ce_comparison FOREIGN KEY (comparison_id) REFERENCES comparisons(id) ON DELETE CASCADE,
-  CONSTRAINT fk_ce_event FOREIGN KEY (event_id) REFERENCES events(id) ON DELETE CASCADE
+  INDEX idx_activity_id (activity_id),
+  CONSTRAINT fk_cea_comparison FOREIGN KEY (comparison_id) REFERENCES comparisons(id) ON DELETE CASCADE,
+  CONSTRAINT fk_cea_event FOREIGN KEY (event_id) REFERENCES events(id) ON DELETE CASCADE,
+  CONSTRAINT fk_cea_activity FOREIGN KEY (activity_id) REFERENCES activities(id) ON DELETE CASCADE
 )
 DEFAULT CHARSET = utf8mb4
 COLLATE = utf8mb4_unicode_ci;

--- a/backend/src/repositories/comparison-repository.js
+++ b/backend/src/repositories/comparison-repository.js
@@ -1,18 +1,18 @@
 const { runQuery } = require('./query-helper');
 const { placeholders } = require('../utils/transforms');
 
-async function create(id, name, eventIds, settings, opts = {}) {
+async function create(id, name, activityRows, settings, opts = {}) {
   if (!opts.userId) throw new Error('create comparison requires opts.userId');
   await runQuery(
     'INSERT INTO comparisons (id, user_id, name, settings) VALUES (?, ?, ?, ?)',
     [id, opts.userId, name, settings ? JSON.stringify(settings) : null],
     opts
   );
-  if (eventIds.length > 0) {
-    const placeholdersList = eventIds.map(() => '(?, ?)').join(', ');
-    const values = eventIds.flatMap((eventId) => [id, eventId]);
+  if (activityRows.length > 0) {
+    const placeholdersList = activityRows.map(() => '(?, ?, ?)').join(', ');
+    const values = activityRows.flatMap((row) => [id, row.eventId, row.activityId]);
     await runQuery(
-      `INSERT INTO comparison_events (comparison_id, event_id) VALUES ${placeholdersList}`,
+      `INSERT INTO comparison_event_activities (comparison_id, event_id, activity_id) VALUES ${placeholdersList}`,
       values,
       opts
     );
@@ -31,23 +31,31 @@ async function findAll(limit, opts = {}) {
 
   const ids = comparisons.map((r) => r.id);
   const linkRows = await runQuery(
-    `SELECT comparison_id, event_id FROM comparison_events WHERE comparison_id IN (${placeholders(ids.length)})`,
+    `SELECT comparison_id, event_id, activity_id FROM comparison_event_activities WHERE comparison_id IN (${placeholders(
+      ids.length
+    )})`,
     ids,
     opts
   );
   const linkArr = Array.isArray(linkRows) ? linkRows : [];
 
   const eventIdsByComparison = {};
+  const activityIdsByComparison = {};
   for (const link of linkArr) {
     if (!eventIdsByComparison[link.comparison_id]) {
       eventIdsByComparison[link.comparison_id] = [];
     }
     eventIdsByComparison[link.comparison_id].push(link.event_id);
+    if (!activityIdsByComparison[link.comparison_id]) {
+      activityIdsByComparison[link.comparison_id] = [];
+    }
+    activityIdsByComparison[link.comparison_id].push(link.activity_id);
   }
 
   return comparisons.map((row) => ({
     ...row,
     event_ids: eventIdsByComparison[row.id] || [],
+    activity_ids: activityIdsByComparison[row.id] || [],
   }));
 }
 
@@ -62,11 +70,17 @@ async function findById(id, opts = {}) {
   if (!row) return null;
 
   const linkRows = await runQuery(
-    'SELECT event_id FROM comparison_events WHERE comparison_id = ?',
+    'SELECT event_id, activity_id FROM comparison_event_activities WHERE comparison_id = ?',
     [id],
     opts
   );
-  row.event_ids = Array.isArray(linkRows) ? linkRows.map((r) => r.event_id) : [];
+  if (Array.isArray(linkRows)) {
+    row.event_ids = linkRows.map((r) => r.event_id);
+    row.activity_ids = linkRows.map((r) => r.activity_id);
+  } else {
+    row.event_ids = [];
+    row.activity_ids = [];
+  }
   return row;
 }
 
@@ -80,8 +94,8 @@ async function findByEventIds(eventIds, opts = {}) {
   const rows = await runQuery(
     `SELECT DISTINCT c.id, c.name, c.created_at
      FROM comparisons c
-     JOIN comparison_events ce ON ce.comparison_id = c.id
-     WHERE ce.event_id IN (${placeholders(eventIds.length)}) AND c.user_id = ?`,
+     JOIN comparison_event_activities cea ON cea.comparison_id = c.id
+     WHERE cea.event_id IN (${placeholders(eventIds.length)}) AND c.user_id = ?`,
     [...eventIds, opts.userId],
     opts
   );

--- a/backend/src/routes/comparisons.js
+++ b/backend/src/routes/comparisons.js
@@ -21,8 +21,8 @@ router.post(
   '/',
   validateComparisonBody,
   asyncHandler(async (req, res) => {
-    const { name, eventIds, settings } = req.body;
-    const comparison = await createComparison(name, eventIds, settings, { userId: req.userId });
+    const { name, activityIds, settings } = req.body;
+    const comparison = await createComparison(name, activityIds, settings, { userId: req.userId });
     res.status(201).json(comparison);
   })
 );

--- a/backend/src/services/account-service.js
+++ b/backend/src/services/account-service.js
@@ -81,15 +81,17 @@ async function exportUserData(userId, opts = {}) {
   const comparisonRows = Array.isArray(comparisons) ? comparisons : [];
   const comparisonIds = comparisonRows.map((c) => c.id);
 
-  // Comparison events (batched)
-  let comparisonEventRows = [];
+  // Comparison events/activities (batched)
+  let comparisonEventActivityRows = [];
   if (comparisonIds.length > 0) {
     const links = await runQuery(
-      `SELECT comparison_id, event_id FROM comparison_events WHERE comparison_id IN (${placeholders(comparisonIds.length)})`,
+      `SELECT comparison_id, event_id, activity_id FROM comparison_event_activities WHERE comparison_id IN (${placeholders(
+        comparisonIds.length
+      )})`,
       comparisonIds,
       dbOpts
     );
-    comparisonEventRows = Array.isArray(links) ? links : [];
+    comparisonEventActivityRows = Array.isArray(links) ? links : [];
   }
 
   // Streams metadata (batched) — always included; data points only if includeStreams
@@ -127,7 +129,7 @@ async function exportUserData(userId, opts = {}) {
     activities: activityRows,
     activityStats: activityStatRows,
     comparisons: comparisonRows,
-    comparisonEvents: comparisonEventRows,
+    comparisonEventActivities: comparisonEventActivityRows,
     streams: streamRows,
     streamDataPoints: includeStreams ? streamDataPointRows : [],
   };

--- a/backend/src/services/comparison-service.js
+++ b/backend/src/services/comparison-service.js
@@ -1,39 +1,51 @@
 const { randomUUID } = require('crypto');
 const defaultDb = require('../db');
 const comparisonRepository = require('../repositories/comparison-repository');
-const eventRepository = require('../repositories/event-repository');
+const activityRepository = require('../repositories/activity-repository');
 const { parseJSONField } = require('../utils/transforms');
 
 /**
  * @param {string} name
- * @param {string[]} eventIds
+ * @param {string[]} activityIds
  * @param {object | null} settings
  * @param {{ db?: object }} [opts] - Optional; opts.db for test injection
- * @returns {Promise<object>} { id, name, eventIds, settings, createdAt }
+ * @returns {Promise<object>} { id, name, eventIds, activityIds, settings, createdAt }
  */
-async function createComparison(name, eventIds, settings, opts = {}) {
+async function createComparison(name, activityIds, settings, opts = {}) {
   if (!opts.userId) throw new Error('createComparison requires opts.userId');
   const db = opts.db ?? defaultDb;
   const id = randomUUID();
   const trimmedName = name.trim();
+  let eventIds = [];
+  let activityIdsOut = [];
 
   await db.transaction(async (conn) => {
     const txOpts = { ...opts, db, conn };
-    // Verify all events belong to the user
-    const events = await eventRepository.findManyByIds(eventIds, txOpts);
-    const ownedIds = new Set(events.map((e) => e.id));
-    if (ownedIds.size !== eventIds.length) {
-      const err = new Error('One or more events not found');
+    // Verify all activities (and their parent events) belong to the user
+    const activities = await activityRepository.findManyByIds(activityIds, txOpts);
+    const ownedActivityIds = new Set(activities.map((a) => a.id));
+    if (ownedActivityIds.size !== activityIds.length) {
+      const err = new Error('One or more activities not found');
       err.statusCode = 404;
       throw err;
     }
-    await comparisonRepository.create(id, trimmedName, eventIds, settings, txOpts);
+
+    const activityRows = activities.map((a) => ({
+      eventId: a.event_id,
+      activityId: a.id,
+    }));
+
+    eventIds = activityRows.map((row) => row.eventId);
+    activityIdsOut = activityRows.map((row) => row.activityId);
+
+    await comparisonRepository.create(id, trimmedName, activityRows, settings, txOpts);
   });
 
   return {
     id,
     name: trimmedName,
     eventIds,
+    activityIds: activityIdsOut,
     settings: settings || null,
     createdAt: Date.now(),
   };
@@ -53,6 +65,7 @@ async function getComparisons(limit = 100, opts = {}) {
     id: row.id,
     name: row.name,
     eventIds: row.event_ids,
+    activityIds: row.activity_ids,
     settings: parseJSONField(row.settings, null),
     createdAt: row.created_at ? new Date(row.created_at).getTime() : undefined,
   }));
@@ -73,6 +86,7 @@ async function getComparisonById(id, opts = {}) {
     id: row.id,
     name: row.name,
     eventIds: row.event_ids,
+    activityIds: row.activity_ids,
     settings: parseJSONField(row.settings, null),
     createdAt: row.created_at ? new Date(row.created_at).getTime() : undefined,
   };

--- a/backend/src/utils/validation.js
+++ b/backend/src/utils/validation.js
@@ -160,19 +160,21 @@ function validateComparisonId(req, res, next) {
  * Validates comparison body for POST /api/comparisons
  */
 function validateComparisonBody(req, res, next) {
-  const { name, eventIds } = req.body;
+  const { name, activityIds } = req.body;
 
   if (!name || typeof name !== 'string' || name.trim().length === 0) {
     return res.status(400).json({ error: 'name must be a non-empty string' });
   }
 
-  if (!Array.isArray(eventIds) || eventIds.length < 2) {
-    return res.status(400).json({ error: 'eventIds must be an array with at least 2 event IDs' });
+  if (!Array.isArray(activityIds) || activityIds.length < 2) {
+    return res
+      .status(400)
+      .json({ error: 'activityIds must be an array with at least 2 activity IDs' });
   }
 
-  for (const eventId of eventIds) {
-    if (!isValidUUID(eventId)) {
-      return res.status(400).json({ error: 'All eventIds must be valid UUIDs' });
+  for (const activityId of activityIds) {
+    if (!isValidUUID(activityId)) {
+      return res.status(400).json({ error: 'All activityIds must be valid UUIDs' });
     }
   }
 

--- a/backend/test/unit/services/account-service.test.js
+++ b/backend/test/unit/services/account-service.test.js
@@ -34,7 +34,7 @@ describe('account-service', () => {
       deepStrictEqual(result.activities, []);
       deepStrictEqual(result.activityStats, []);
       deepStrictEqual(result.comparisons, []);
-      deepStrictEqual(result.comparisonEvents, []);
+      deepStrictEqual(result.comparisonEventActivities, []);
       deepStrictEqual(result.streams, []);
       deepStrictEqual(result.streamDataPoints, []);
     });
@@ -60,8 +60,8 @@ describe('account-service', () => {
         if (sql.includes('FROM comparisons WHERE')) {
           return [{ id: 'c1', name: 'Comp', settings: '{}', created_at: new Date('2025-01-01') }];
         }
-        if (sql.includes('FROM comparison_events')) {
-          return [{ comparison_id: 'c1', event_id: 'e1' }];
+        if (sql.includes('FROM comparison_event_activities')) {
+          return [{ comparison_id: 'c1', event_id: 'e1', activity_id: 'a1' }];
         }
         if (sql.includes('FROM streams WHERE')) {
           return [{ id: 's1', activity_id: 'a1', event_id: 'e1', type: 'heartrate', created_at: new Date('2025-01-01') }];
@@ -77,7 +77,7 @@ describe('account-service', () => {
       strictEqual(result.activities.length, 1);
       strictEqual(result.activityStats.length, 1);
       strictEqual(result.comparisons.length, 1);
-      strictEqual(result.comparisonEvents.length, 1);
+      strictEqual(result.comparisonEventActivities.length, 1);
       strictEqual(result.streams.length, 1);
       deepStrictEqual(result.streamDataPoints, []);
     });

--- a/backend/test/unit/services/comparison-service.test.js
+++ b/backend/test/unit/services/comparison-service.test.js
@@ -16,16 +16,16 @@ describe('comparison-service', () => {
       const queries = [];
       const db = makeFakeDb(async (sql, params) => {
         queries.push({ sql, params });
-        if (sql.includes('FROM events')) {
+        if (sql.includes('FROM activities a')) {
           return [
-            { id: 'e1' },
-            { id: 'e2' },
+            { id: 'a1', event_id: 'e1' },
+            { id: 'a2', event_id: 'e2' },
           ];
         }
         return { affectedRows: 1 };
       });
 
-      const result = await createComparison(' My Compare ', ['e1', 'e2'], { x: 1 }, { db, userId: 'u1' });
+      const result = await createComparison(' My Compare ', ['a1', 'a2'], { x: 1 }, { db, userId: 'u1' });
 
       strictEqual(queries.length, 3);
       const insertComp = queries.find((q) => q.sql.startsWith('INSERT INTO comparisons'));
@@ -33,12 +33,15 @@ describe('comparison-service', () => {
       strictEqual(insertComp.params[2], 'My Compare');
       deepStrictEqual(JSON.parse(insertComp.params[3]), { x: 1 });
 
-      const linkInsert = queries.find((q) => q.sql.includes('INSERT INTO comparison_events'));
+      const linkInsert = queries.find((q) =>
+        q.sql.includes('INSERT INTO comparison_event_activities')
+      );
       strictEqual(Boolean(linkInsert), true);
 
       strictEqual(typeof result.id, 'string');
       strictEqual(result.name, 'My Compare');
       deepStrictEqual(result.eventIds, ['e1', 'e2']);
+      deepStrictEqual(result.activityIds, ['a1', 'a2']);
       deepStrictEqual(result.settings, { x: 1 });
       strictEqual(typeof result.createdAt, 'number');
     });
@@ -47,16 +50,16 @@ describe('comparison-service', () => {
       const queries = [];
       const db = makeFakeDb(async (sql, params) => {
         queries.push({ sql, params });
-        if (sql.includes('FROM events')) {
+        if (sql.includes('FROM activities a')) {
           return [
-            { id: 'e1' },
-            { id: 'e2' },
+            { id: 'a1', event_id: 'e1' },
+            { id: 'a2', event_id: 'e2' },
           ];
         }
         return { affectedRows: 1 };
       });
 
-      const result = await createComparison('Test', ['e1', 'e2'], null, { db, userId: 'u1' });
+      const result = await createComparison('Test', ['a1', 'a2'], null, { db, userId: 'u1' });
 
       const insertComp = queries.find((q) => q.sql.startsWith('INSERT INTO comparisons'));
       strictEqual(Boolean(insertComp), true);
@@ -64,23 +67,23 @@ describe('comparison-service', () => {
       strictEqual(result.settings, null);
     });
 
-    it('rejects with statusCode 404 when fewer events found than requested (transaction rolls back)', async () => {
+    it('rejects with statusCode 404 when fewer activities found than requested (transaction rolls back)', async () => {
       const queries = [];
       const db = makeFakeDb(async (sql, params) => {
         queries.push({ sql, params });
-        if (sql.includes('FROM events')) {
-          return [{ id: 'e1' }];
+        if (sql.includes('FROM activities a')) {
+          return [{ id: 'a1', event_id: 'e1' }];
         }
         return { affectedRows: 1 };
       });
 
       await assert.rejects(
         async () => {
-          await createComparison('Test', ['e1', 'e2', 'e3'], null, { db, userId: 'u1' });
+          await createComparison('Test', ['a1', 'a2', 'a3'], null, { db, userId: 'u1' });
         },
         (err) => {
           strictEqual(err.statusCode, 404);
-          strictEqual(err.message, 'One or more events not found');
+          strictEqual(err.message, 'One or more activities not found');
           return true;
         }
       );
@@ -104,10 +107,10 @@ describe('comparison-service', () => {
               },
             ];
           }
-          if (sql.includes('FROM comparison_events')) {
+          if (sql.includes('FROM comparison_event_activities')) {
             return [
-              { comparison_id: 'c1', event_id: 'e1' },
-              { comparison_id: 'c1', event_id: 'e2' },
+              { comparison_id: 'c1', event_id: 'e1', activity_id: 'a1' },
+              { comparison_id: 'c1', event_id: 'e2', activity_id: 'a2' },
             ];
           }
           return [];
@@ -120,6 +123,7 @@ describe('comparison-service', () => {
       strictEqual(result[0].id, 'c1');
       strictEqual(result[0].name, 'C1');
       deepStrictEqual(result[0].eventIds, ['e1', 'e2']);
+      deepStrictEqual(result[0].activityIds, ['a1', 'a2']);
       deepStrictEqual(result[0].settings, {});
       strictEqual(result[0].createdAt, new Date('2025-01-01T00:00:00Z').getTime());
     });
@@ -151,8 +155,11 @@ describe('comparison-service', () => {
               },
             ];
           }
-          if (sql.includes('FROM comparison_events')) {
-            return [{ event_id: 'e1' }, { event_id: 'e2' }];
+          if (sql.includes('FROM comparison_event_activities')) {
+            return [
+              { event_id: 'e1', activity_id: 'a1' },
+              { event_id: 'e2', activity_id: 'a2' },
+            ];
           }
           return [];
         },
@@ -162,6 +169,7 @@ describe('comparison-service', () => {
 
       strictEqual(result.id, 'c1');
       deepStrictEqual(result.eventIds, ['e1', 'e2']);
+      deepStrictEqual(result.activityIds, ['a1', 'a2']);
       strictEqual(result.settings, null);
     });
   });

--- a/backend/test/unit/validation.test.js
+++ b/backend/test/unit/validation.test.js
@@ -308,7 +308,7 @@ describe('validateComparisonBody', () => {
     const req = {
       body: {
         name: 'My Comparison',
-        eventIds: [
+        activityIds: [
           'a1b2c3d4-e5f6-4789-a012-3456789abcde',
           'b2c3d4e5-f6a7-4890-b123-456789abcdef',
         ],
@@ -324,7 +324,10 @@ describe('validateComparisonBody', () => {
     const req = {
       body: {
         name: '',
-        eventIds: ['a1b2c3d4-e5f6-4789-a012-3456789abcde', 'b2c3d4e5-f6a7-4890-b123-456789abcdef'],
+        activityIds: [
+          'a1b2c3d4-e5f6-4789-a012-3456789abcde',
+          'b2c3d4e5-f6a7-4890-b123-456789abcdef',
+        ],
       },
     };
     const res = mockRes();
@@ -336,12 +339,14 @@ describe('validateComparisonBody', () => {
   });
 
   it('returns 400 when eventIds has fewer than 2 elements', () => {
-    const req = { body: { name: 'Compare', eventIds: ['a1b2c3d4-e5f6-4789-a012-3456789abcde'] } };
+    const req = { body: { name: 'Compare', activityIds: ['a1b2c3d4-e5f6-4789-a012-3456789abcde'] } };
     const res = mockRes();
     const next = mockNext();
     validateComparisonBody(req, res, next);
     strictEqual(res.statusCode, 400);
-    deepStrictEqual(res.body, { error: 'eventIds must be an array with at least 2 event IDs' });
+    deepStrictEqual(res.body, {
+      error: 'activityIds must be an array with at least 2 activity IDs',
+    });
     strictEqual(next.called(), false);
   });
 
@@ -349,14 +354,14 @@ describe('validateComparisonBody', () => {
     const req = {
       body: {
         name: 'Compare',
-        eventIds: ['a1b2c3d4-e5f6-4789-a012-3456789abcde', 'not-a-uuid'],
+        activityIds: ['a1b2c3d4-e5f6-4789-a012-3456789abcde', 'not-a-uuid'],
       },
     };
     const res = mockRes();
     const next = mockNext();
     validateComparisonBody(req, res, next);
     strictEqual(res.statusCode, 400);
-    deepStrictEqual(res.body, { error: 'All eventIds must be valid UUIDs' });
+    deepStrictEqual(res.body, { error: 'All activityIds must be valid UUIDs' });
     strictEqual(next.called(), false);
   });
 });

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -158,7 +158,7 @@ erDiagram
     }
 ```
 
-All relationships use foreign keys with **ON DELETE CASCADE**. Deleting a **user** cascades to user_identities, events (and their event_stats, activities, activity_stats, streams, stream_data_points), and comparisons (and comparison_events). Deleting an **event**: the event-delete-service first deletes any comparisons that reference the event (in a transaction), then `DELETE FROM events WHERE id = ?`; CASCADE removes event_stats, activities, activity_stats, streams, stream_data_points, and comparison_events. Deleting an activity or stream cascades to their stats and stream_data_points respectively.
+All relationships use foreign keys with **ON DELETE CASCADE**. Deleting a **user** cascades to user_identities, events (and their event_stats, activities, activity_stats, streams, stream_data_points), and comparisons (and comparison_event_activities). Deleting an **event**: the event-delete-service first deletes any comparisons that reference the event (in a transaction), then `DELETE FROM events WHERE id = ?`; CASCADE removes event_stats, activities, activity_stats, streams, stream_data_points, and comparison_event_activities. Deleting an activity or stream cascades to their stats and stream_data_points respectively.
 
 ### Event vs Activity: Core Concepts
 
@@ -296,20 +296,21 @@ Timestamped data points for each stream. Stored relationally with timestamps for
 - Indexes: `(stream_id, time_ms)`, `stream_id`, `time_ms`
 
 #### comparisons
-Saved comparison definitions (optional feature). Owned by a user; event membership is stored in `comparison_events`, not as JSON.
+Saved comparison definitions (optional feature). Owned by a user; per-event activity membership is stored in `comparison_event_activities`, not as JSON.
 
 - `id`: UUID primary key
 - `user_id`: FK to users ON DELETE CASCADE; all queries scope by this
 - `name`: User-defined name
-- `settings`: JSON (e.g. selectedStreams, xAxisMode, selectedActivities)
+- `settings`: JSON (e.g. selectedStreams, xAxisMode)
 - `created_at`: Row creation timestamp
 
-#### comparison_events
-Link table between comparisons and events (many-to-many).
+#### comparison_event_activities
+Link table between comparisons, events, and activities. Each comparison can reference one activity per event.
 
 - `comparison_id`: FK to comparisons(id) ON DELETE CASCADE
 - `event_id`: FK to events(id) ON DELETE CASCADE
-- Primary key (comparison_id, event_id). Index on event_id for “comparisons by event” queries.
+- `activity_id`: FK to activities(id) ON DELETE CASCADE
+- Primary key (comparison_id, event_id). Indexes on `event_id` (for “comparisons by event” queries) and `activity_id`.
 
 ## API Design
 
@@ -471,8 +472,8 @@ Delete an event and all related data.
 - 404 Not Found (event doesn't exist)
 
 **Deletion (in a single transaction):**
-1. Find comparisons that reference this event (via comparison_events) and delete those comparisons (CASCADE removes their comparison_events rows).
-2. Delete the event; CASCADE then removes event_stats, activities, activity_stats, streams, stream_data_points, and any remaining comparison_events rows.
+1. Find comparisons that reference this event (via comparison_event_activities) and delete those comparisons (CASCADE removes their comparison_event_activities rows).
+2. Delete the event; CASCADE then removes event_stats, activities, activity_stats, streams, stream_data_points, and any remaining comparison_event_activities rows.
 
 #### GET /api/activity-types
 Returns distinct activity types from the current user's activities. **Response:** JSON array of strings (e.g. `["Running", "Cycling"]`).
@@ -482,9 +483,9 @@ Returns distinct device names from the current user's activities. **Response:** 
 
 #### Comparisons API
 
-- **GET /api/comparisons** – List saved comparisons. **Response:** Array of `{ id, name, eventIds, settings?, createdAt? }`. `eventIds` are read from comparison_events; `createdAt` is milliseconds.
+- **GET /api/comparisons** – List saved comparisons. **Response:** Array of `{ id, name, eventIds, activityIds, settings?, createdAt? }`. `eventIds`/`activityIds` are read from `comparison_event_activities`; `createdAt` is milliseconds.
 - **GET /api/comparisons/:id** – Get one comparison. **Response:** Same shape. 404 if not found.
-- **POST /api/comparisons** – Create comparison. **Body:** `{ name: string, eventIds: string[], settings?: { selectedStreams?, xAxisMode?, selectedActivities? } }`. **Response:** 201 with created comparison. Backend stores event links in comparison_events.
+- **POST /api/comparisons** – Create comparison. **Body:** `{ name: string, activityIds: string[], settings?: { selectedStreams?, xAxisMode? } }`. **Response:** 201 with created comparison. Backend stores event/activity links in `comparison_event_activities`.
 - **POST /api/comparisons/by-events** – Find comparisons linked to any of the given event IDs (e.g. for delete warnings). **Body:** `{ eventIds: string[] }` (non-empty, valid UUIDs). **Response:** Array of `{ id, name, createdAt? }`.
 - **DELETE /api/comparisons/:id** – Delete comparison. **Response:** 204 No Content or 404 Not Found.
 

--- a/frontend/src/lib/api/__tests__/comparisons.test.ts
+++ b/frontend/src/lib/api/__tests__/comparisons.test.ts
@@ -209,7 +209,7 @@ describe('createComparison', () => {
     });
     vi.stubGlobal('fetch', mockFetch);
 
-    const result = await createComparison('Run vs Ride', ['evt-1', 'evt-2']);
+    const result = await createComparison('Run vs Ride', ['act-1', 'act-2']);
 
     expect(result).toEqual(comparisonFixture);
     expect(mockFetch).toHaveBeenCalledWith(
@@ -218,7 +218,7 @@ describe('createComparison', () => {
         method: 'POST',
         body: JSON.stringify({
           name: 'Run vs Ride',
-          eventIds: ['evt-1', 'evt-2'],
+          activityIds: ['act-1', 'act-2'],
           settings: undefined,
         }),
         credentials: 'include',
@@ -233,7 +233,7 @@ describe('createComparison', () => {
     });
     vi.stubGlobal('fetch', mockFetch);
 
-    await createComparison('Detailed', ['evt-1'], {
+    await createComparison('Detailed', ['act-1'], {
       selectedStreams: ['Heart Rate'],
     });
 
@@ -251,7 +251,7 @@ describe('createComparison', () => {
       })
     );
 
-    await expect(createComparison('Duplicate', ['evt-1'])).rejects.toThrow('Duplicate name');
+    await expect(createComparison('Duplicate', ['act-1'])).rejects.toThrow('Duplicate name');
   });
 
   it('throws statusText when body has no error key', async () => {
@@ -265,7 +265,7 @@ describe('createComparison', () => {
       })
     );
 
-    await expect(createComparison('Test', ['evt-1'])).rejects.toThrow(
+    await expect(createComparison('Test', ['act-1'])).rejects.toThrow(
       /Failed to create comparison/
     );
   });

--- a/frontend/src/lib/api/comparisons.ts
+++ b/frontend/src/lib/api/comparisons.ts
@@ -14,6 +14,9 @@ function assertComparison(data: unknown): asserts data is Comparison {
   if (!Array.isArray(d.eventIds)) {
     throw new Error('Invalid comparison response: missing eventIds array');
   }
+  if (!Array.isArray(d.activityIds)) {
+    throw new Error('Invalid comparison response: missing activityIds array');
+  }
 }
 
 export async function getComparisonCandidates(eventId: string): Promise<EventSummary[]> {
@@ -85,7 +88,7 @@ export async function getComparisonsByEventIds(eventIds: string[]): Promise<Comp
 
 export async function createComparison(
   name: string,
-  eventIds: string[],
+  activityIds: string[],
   settings?: ComparisonSettings
 ): Promise<Comparison> {
   const response = await apiFetch(`${API_BASE}/comparisons`, {
@@ -93,7 +96,7 @@ export async function createComparison(
     headers: {
       'Content-Type': 'application/json',
     },
-    body: JSON.stringify({ name, eventIds, settings }),
+    body: JSON.stringify({ name, activityIds, settings }),
   });
 
   if (!response.ok) {

--- a/frontend/src/lib/types/event.ts
+++ b/frontend/src/lib/types/event.ts
@@ -63,13 +63,14 @@ export interface BatchUploadResponse {
 export interface ComparisonSettings {
   selectedStreams?: string[];
   xAxisMode?: 'elapsed' | 'wall-clock';
-  selectedActivities?: Record<string, string>; // eventId -> activityId
 }
 
 export interface Comparison {
   id: string;
   name: string;
   eventIds: string[];
+  /** Activity IDs for the comparison, parallel to eventIds (same order). */
+  activityIds?: string[];
   settings?: ComparisonSettings;
   createdAt?: number;
 }

--- a/frontend/src/lib/utils/comparison-loader.svelte.ts
+++ b/frontend/src/lib/utils/comparison-loader.svelte.ts
@@ -82,15 +82,22 @@ async function loadEventsAndStreams(
   state.events = loadedEvents;
 
   let activitiesChanged = false;
-  const nextActivities = { ...state.selectedActivities };
+  const nextActivities: Record<string, string> = {};
   for (const eventDetail of loadedEvents) {
     const eventId = eventDetail.event.id;
-    if (!nextActivities[eventId] && eventDetail.activities.length > 0) {
+    const existingActivityId = state.selectedActivities[eventId];
+    const hasExistingActivity =
+      !!existingActivityId &&
+      eventDetail.activities.some((activity) => activity.id === existingActivityId);
+
+    if (hasExistingActivity) {
+      nextActivities[eventId] = existingActivityId;
+    } else if (eventDetail.activities.length > 0) {
       nextActivities[eventId] = eventDetail.activities[0].id;
       activitiesChanged = true;
     }
   }
-  if (activitiesChanged && myGen === loadGeneration) {
+  if (myGen === loadGeneration) {
     state.selectedActivities = nextActivities;
   }
 
@@ -167,6 +174,9 @@ export function load(comparisonId: string, eventIdsFromQuery: string[]): void {
   state.error = null;
   if (comparisonId === 'new') {
     state.comparison = null;
+    state.selectedActivities = {};
+    state.selectedStreamTypes = new Set();
+    state.xAxisMode = 'elapsed';
   }
 
   if (abortController) abortController.abort();
@@ -208,7 +218,14 @@ export function load(comparisonId: string, eventIdsFromQuery: string[]): void {
       if (comp.settings) {
         state.xAxisMode = comp.settings.xAxisMode ?? 'elapsed';
         state.selectedStreamTypes = new Set(comp.settings.selectedStreams ?? []);
-        state.selectedActivities = comp.settings.selectedActivities ?? {};
+      }
+      if (Array.isArray(comp.eventIds) && Array.isArray(comp.activityIds)) {
+        const nextSelectedActivities: Record<string, string> = {};
+        const len = Math.min(comp.eventIds.length, comp.activityIds.length);
+        for (let i = 0; i < len; i += 1) {
+          nextSelectedActivities[comp.eventIds[i]] = comp.activityIds[i];
+        }
+        state.selectedActivities = nextSelectedActivities;
       }
       const ids = comp.eventIds;
       if (ids.length < 2) {

--- a/frontend/src/routes/__tests__/comparison-view.test.ts
+++ b/frontend/src/routes/__tests__/comparison-view.test.ts
@@ -154,7 +154,7 @@ describe('ComparisonView', () => {
     await waitFor(() => {
       expect(mockCreateComparison).toHaveBeenCalledWith(
         'My Compare',
-        ['evt-1', 'evt-2'],
+        ['act-1', 'act-2'],
         expect.any(Object)
       );
     });

--- a/frontend/src/routes/comparison-view.svelte
+++ b/frontend/src/routes/comparison-view.svelte
@@ -248,13 +248,16 @@
 
     isSaving = true;
     try {
+      const activityIds = eventIds
+        .map((id) => loaderState.selectedActivities[id])
+        .filter((id): id is string => Boolean(id));
+
       const settings: ComparisonSettings = {
         selectedStreams: Array.from(loaderState.selectedStreamTypes),
         xAxisMode: loaderState.xAxisMode,
-        selectedActivities: { ...loaderState.selectedActivities },
       };
 
-      const saved = await createComparison(saveName.trim(), eventIds, settings);
+      const saved = await createComparison(saveName.trim(), activityIds, settings);
       setComparison(saved);
       showSaveDialog = false;
       saveName = '';

--- a/frontend/src/test/fixtures/comparisons.ts
+++ b/frontend/src/test/fixtures/comparisons.ts
@@ -4,6 +4,7 @@ export const comparisonFixture = {
   id: 'cmp-1',
   name: 'Run vs Ride',
   eventIds: ['evt-1', 'evt-2'],
+  activityIds: ['act-1', 'act-2'],
   createdAt: 1700000000000,
 } satisfies Comparison;
 
@@ -11,10 +12,10 @@ export const comparisonWithSettingsFixture = {
   id: 'cmp-2',
   name: 'Detailed comparison',
   eventIds: ['evt-1', 'evt-2'],
+  activityIds: ['act-1', 'act-2'],
   settings: {
     selectedStreams: ['Heart Rate', 'Speed'],
     xAxisMode: 'elapsed' as const,
-    selectedActivities: { 'evt-1': 'act-1', 'evt-2': 'act-2' },
   },
   createdAt: 1700000000000,
 } satisfies Comparison;


### PR DESCRIPTION
**Changes:**

- **Data model**: Replaced the old `comparison_events` table with a new `comparison_event_activities` table `(comparison_id, event_id, activity_id)` in `schema.sql`, updated `comparison-repository`, `comparison-service`, `event-delete-service` usage, `account-service` export shape, and all related backend tests and docs (`AGENTS.md`, `docs/ARCHITECTURE.md`) to reflect event+activity links and the new `{ id, name, eventIds, activityIds, settings?, createdAt? }` comparison shape.
- **Backend API + validation**: `POST /api/comparisons` now accepts `activityIds` instead of `eventIds`, validates them via `validateComparisonBody`, and `createComparison` verifies activities through `activityRepository.findManyByIds`, returning both `eventIds` and `activityIds` to the client.
- **Frontend types, API, and behavior**: Updated `ComparisonSettings`/`Comparison` types, `comparisons.ts` (create now sends `activityIds`, `assertComparison` requires `activityIds`), `comparison-loader` to build `selectedActivities` from the relational `eventIds`/`activityIds` pair instead of settings JSON, and `comparison-view` so `handleSave` derives `activityIds` from the current `selectedActivities`.
- **Bugs & tests**: Fixed the `selectedActivities` state-leak bug (reset on new comparisons and scoped to loaded events), adjusted test fixtures and comparison tests (backend and frontend) to cover the new activity-based model and ensure saving/loading comparisons—including multi-activity scenarios—now work correctly; all backend tests and full frontend CI (format, lint, check, test, build) pass.