### PR TITLE
Remove unused `stream_data_points.created_at` and `activities.event_start_date`

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -124,7 +124,7 @@ On **push to main** and **pull_request** targeting main:
   - `sessions` - express-session store (session_id, expires, data). Managed by express-mysql-session.
   - `events` - Event metadata (id, user_id, start_date, name, end_date, description, is_merge, src_file_type, created_at). FK to users ON DELETE CASCADE.
   - `event_stats` - Event-level statistics (event_id, stat_type, value JSON)
-  - `activities` - Activity metadata (id, event_id, name, start_date, end_date, type, event_start_date, device_name, created_at)
+  - `activities` - Activity metadata (id, event_id, name, start_date, end_date, type, device_name, created_at)
   - `activity_stats` - Activity-level statistics (activity_id, stat_type, value JSON)
   - `streams` - Stream metadata (id, activity_id, event_id, type)
   - `stream_data_points` - Timestamped stream data (id, stream_id, time_ms BIGINT, value JSON, sequence_index)

--- a/backend/sql/schema.sql
+++ b/backend/sql/schema.sql
@@ -76,7 +76,6 @@ CREATE TABLE IF NOT EXISTS activities (
   start_date BIGINT NULL,
   end_date BIGINT NULL,
   type VARCHAR(128) NULL,
-  event_start_date BIGINT NULL,
   device_name VARCHAR(255) NULL,
   start_timezone VARCHAR(64) NULL,
   end_timezone VARCHAR(64) NULL,
@@ -123,7 +122,6 @@ CREATE TABLE IF NOT EXISTS stream_data_points (
   time_ms BIGINT NOT NULL,
   value JSON NOT NULL,
   sequence_index INT,
-  created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
   INDEX idx_stream_time (stream_id, time_ms),
   INDEX idx_stream_sequence (stream_id, sequence_index, time_ms),
   CONSTRAINT fk_stream_data_points_stream FOREIGN KEY (stream_id) REFERENCES streams (id) ON DELETE CASCADE

--- a/backend/src/repositories/activity-repository.js
+++ b/backend/src/repositories/activity-repository.js
@@ -2,10 +2,10 @@ const { runQuery } = require('./query-helper');
 const { placeholders } = require('../utils/transforms');
 
 const ACTIVITY_COLUMNS =
-  'a.id, a.event_id, a.name, a.start_date, a.end_date, a.type, a.event_start_date, a.device_name, a.start_timezone, a.end_timezone';
+  'a.id, a.event_id, a.name, a.start_date, a.end_date, a.type, a.device_name, a.start_timezone, a.end_timezone';
 
 async function insertActivity(row, opts = {}) {
-  const sql = `INSERT INTO activities (id, event_id, name, start_date, end_date, type, event_start_date, device_name, start_timezone, end_timezone) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`;
+  const sql = `INSERT INTO activities (id, event_id, name, start_date, end_date, type, device_name, start_timezone, end_timezone) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`;
   await runQuery(
     sql,
     [
@@ -15,7 +15,6 @@ async function insertActivity(row, opts = {}) {
       row.start_date,
       row.end_date,
       row.type,
-      row.event_start_date,
       row.device_name,
       row.start_timezone,
       row.end_timezone,

--- a/backend/src/services/event-upload-service.js
+++ b/backend/src/services/event-upload-service.js
@@ -79,7 +79,6 @@ async function processUpload(fileBuffer, extension, originalFilename, opts = {})
           start_date: aStartDate,
           end_date: aEndDate,
           type: aType,
-          event_start_date: startDate,
           device_name: deviceName || null,
           start_timezone: startTimezone,
           end_timezone: endTimezone,

--- a/backend/src/utils/transforms.js
+++ b/backend/src/utils/transforms.js
@@ -49,7 +49,6 @@ function mapActivityRow(row, statsForActivity = {}) {
   return {
     id: row.id,
     eventID: row.event_id,
-    eventStartDate: row.event_start_date != null ? Number(row.event_start_date) : undefined,
     ...(row.name != null ? { name: row.name } : {}),
     ...(row.start_date != null ? { startDate: Number(row.start_date) } : {}),
     ...(row.end_date != null ? { endDate: Number(row.end_date) } : {}),

--- a/backend/test/unit/services/activity-service.test.js
+++ b/backend/test/unit/services/activity-service.test.js
@@ -21,7 +21,6 @@ describe('updateActivity', () => {
       start_date: 1000,
       end_date: 2000,
       type: 'Running',
-      event_start_date: 1000,
       device_name: 'Garmin',
     };
     const conn = {
@@ -50,7 +49,6 @@ describe('updateActivity', () => {
       start_date: 1000,
       end_date: null,
       type: 'Running',
-      event_start_date: 1000,
       device_name: null,
     };
     const executed = [];

--- a/backend/test/unit/services/event-query-service.test.js
+++ b/backend/test/unit/services/event-query-service.test.js
@@ -46,7 +46,6 @@ describe('enrichEventsWithStatsAndActivities', () => {
               start_date: 1000,
               end_date: 2000,
               type: 'Running',
-              event_start_date: 1000,
               device_name: 'Garmin',
             },
           ];
@@ -114,7 +113,6 @@ describe('getEventById', () => {
         start_date: 1000,
         end_date: 2000,
         type: 'Running',
-        event_start_date: 1000,
         device_name: 'Garmin',
       },
     ];
@@ -205,8 +203,8 @@ describe('getActivityRows', () => {
         }
         if (sql.includes('FROM activities a') && sql.includes('WHERE a.id IN')) {
           return [
-            { id: 'a1', event_id: 'e1', name: null, start_date: 1000, end_date: null, type: 'Run', event_start_date: 1000, device_name: null },
-            { id: 'a2', event_id: 'e2', name: null, start_date: 2000, end_date: null, type: 'Run', event_start_date: 2000, device_name: null },
+            { id: 'a1', event_id: 'e1', name: null, start_date: 1000, end_date: null, type: 'Run', device_name: null },
+            { id: 'a2', event_id: 'e2', name: null, start_date: 2000, end_date: null, type: 'Run', device_name: null },
           ];
         }
         if (sql.includes('event_stats')) return [];

--- a/backend/test/unit/transforms.test.js
+++ b/backend/test/unit/transforms.test.js
@@ -184,7 +184,6 @@ describe('mapActivityRow', () => {
     deepStrictEqual(result, {
       id: 'a1',
       eventID: 'e1',
-      eventStartDate: undefined,
       stats: {},
     });
   });
@@ -197,7 +196,6 @@ describe('mapActivityRow', () => {
       start_date: 1609459200000,
       end_date: 1609462800000,
       type: 'Running',
-      event_start_date: 1609459200000,
       device_name: 'Garmin',
       start_timezone: 'America/New_York',
       end_timezone: 'America/New_York',
@@ -206,7 +204,6 @@ describe('mapActivityRow', () => {
     deepStrictEqual(mapActivityRow(row, stats), {
       id: 'a1',
       eventID: 'e1',
-      eventStartDate: 1609459200000,
       name: 'Lap 1',
       startDate: 1609459200000,
       endDate: 1609462800000,

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -116,7 +116,6 @@ erDiagram
         bigint start_date
         bigint end_date
         varchar type
-        bigint event_start_date
         varchar device_name
         timestamp created_at
     }
@@ -264,7 +263,6 @@ Individual activities within an event. An event can contain multiple activities 
 - `start_date`: Activity start timestamp
 - `end_date`: Activity end timestamp
 - `type`: Activity type (e.g., "Running", "Cycling", "Swimming")
-- `event_start_date`: Denormalized event start date for convenience
 - `device_name`: Device or tracker name (e.g. "Garmin Forerunner 945") (VARCHAR(255), nullable)
 - `created_at`: Row creation timestamp
 
@@ -394,7 +392,6 @@ Get a single event with all activities.
     {
       "id": "uuid",
       "eventID": "uuid",
-      "eventStartDate": 1771317117000,
       "name": "Running",
       "startDate": 1771317117000,
       "type": "Running",

--- a/frontend/src/lib/types/event.ts
+++ b/frontend/src/lib/types/event.ts
@@ -20,7 +20,6 @@ export interface EventDetail {
 export interface Activity {
   id: string;
   eventID: string;
-  eventStartDate?: number;
   name?: string;
   startDate?: number;
   endDate?: number;

--- a/frontend/src/test/fixtures/event-detail.ts
+++ b/frontend/src/test/fixtures/event-detail.ts
@@ -3,7 +3,6 @@ import type { EventDetail, EventSummary, Activity } from '../../lib/types/event'
 const activityFixture = {
   id: 'act-1',
   eventID: 'evt-1',
-  eventStartDate: 1700000000000,
   name: 'Morning Run',
   startDate: 1700000000000,
   endDate: 1700003600000,


### PR DESCRIPTION
**Changes:**

- Drop created_at from stream_data_points (never read)
- Drop event_start_date from activities (redundant with event.start_date)
- Update activity-repository, event-upload-service, transforms
- Update Activity type and fixtures; update docs and tests