### PR TITLE
feat: store sessions in Valkey instead of MariaDB

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -31,7 +31,7 @@ This file provides operational instructions for AI coding agents working in this
   - Requires Node 24+ (from backend/package.json engines)
 
 - **Dependencies:**
-  - Main: `@sports-alliance/sports-lib`, `@dr.pogodin/csurf`, `express`, `mysql2`, `multer`, `cors`, `xmldom`, `passport`, `passport-google-oauth20`, `passport-github2`, `express-session`, `express-mysql-session`, `helmet`, `express-rate-limit`
+  - Main: `@sports-alliance/sports-lib`, `@dr.pogodin/csurf`, `connect-redis`, `express`, `mysql2`, `multer`, `cors`, `redis`, `xmldom`, `passport`, `passport-google-oauth20`, `passport-github2`, `express-session`, `helmet`, `express-rate-limit`
   - Dev: `eslint`, `eslint-plugin-security`, `prettier`, `supertest`, etc.
   - Install: `cd backend && npm install`
 
@@ -97,7 +97,7 @@ On **push to main** and **pull_request** targeting main:
   - `backend/src/routes/account.js` - Account routes (GET /api/account/export, DELETE /api/account)
   - `backend/src/services/` - Business logic (event-query-service, event-upload-service, event-delete-service, comparison-service, stream-service, activity-service, meta-service, account-service)
   - `backend/src/repositories/user-repository.js` - User and identity CRUD; findOrCreateByIdentity for OAuth
-  - `backend/src/middleware/session.js` - express-session + MySQL store
+  - `backend/src/middleware/session.js` - express-session + Valkey store (connect-redis)
   - `backend/src/middleware/csrf.js` - CSRF protection (session-based token; validates on state-changing methods)
   - `backend/src/middleware/require-auth.js` - Require valid session; set req.userId
   - `backend/src/middleware/passport.js` - Passport strategies (Google, GitHub)
@@ -121,7 +121,7 @@ On **push to main** and **pull_request** targeting main:
 - **Database schema:**
   - `users` - User profile (id UUID, display_name, avatar_url, created_at, updated_at). No email on users; email lives in user_identities.
   - `user_identities` - OAuth identities (id, user_id, provider, provider_user_id, email, profile_data JSON). Unique (provider, provider_user_id). FK to users ON DELETE CASCADE.
-  - `sessions` - express-session store (session_id, expires, data). Managed by express-mysql-session.
+  - Sessions are stored in Valkey (not in DB). See `backend/src/middleware/session.js` and config `valkey`.
   - `events` - Event metadata (id, user_id, start_date, name, end_date, description, is_merge, src_file_type, created_at). FK to users ON DELETE CASCADE.
   - `event_stats` - Event-level statistics (event_id, stat_type, value JSON)
   - `activities` - Activity metadata (id, event_id, name, start_date, end_date, type, device_name, created_at)
@@ -131,7 +131,7 @@ On **push to main** and **pull_request** targeting main:
   - `comparisons` - Saved comparison definitions (id, user_id, name, settings JSON, created_at). Per-event activity membership is in `comparison_event_activities`. FK to users ON DELETE CASCADE.
   - `comparison_event_activities` - Link table (comparison_id, event_id, activity_id) with FK to comparisons, events, and activities ON DELETE CASCADE. Each comparison can reference one activity per event (PK is (comparison_id, event_id)).
   - Foreign keys with ON DELETE CASCADE: user_identities → users; event_stats → events; activities → events; activity_stats → activities; streams → activities, events; stream_data_points → streams; comparison_event_activities → comparisons, events, activities; events → users; comparisons → users. Deleting a user cascades to identities, events (and their stats, activities, streams, stream_data_points), and comparisons (and comparison_event_activities). Deleting an event: event-delete-service deletes comparisons that reference it (in a transaction), then deletes the event; CASCADE removes related rows.
-  - Indexes: foreign keys; users (id); user_identities (user_id, uk_provider_identity); sessions (expires); events (user_id, start_date, idx_user_start_date); activities (event_id, type, device_name, start_date); stream_data_points (stream_id, time_ms; stream_id, sequence_index, time_ms); comparisons (user_id, created_at); comparison_event_activities (event_id, activity_id).
+  - Indexes: foreign keys; users (id); user_identities (user_id, uk_provider_identity); events (user_id, start_date, idx_user_start_date); activities (event_id, type, device_name, start_date); stream_data_points (stream_id, time_ms; stream_id, sequence_index, time_ms); comparisons (user_id, created_at); comparison_event_activities (event_id, activity_id).
   - Schema auto-initializes on API startup via `db.initializeSchema()`
 
 ## API endpoints
@@ -214,7 +214,7 @@ Full request/response details: [docs/ARCHITECTURE.md](docs/ARCHITECTURE.md).
 
 ## Key architectural decisions
 
-- **Authentication:** Backend-managed OAuth (Google, GitHub) with server-side session cookies (express-session, MySQL store). Session is HttpOnly, Secure in production, SameSite=Lax. No JWTs in localStorage. SPA calls `GET /api/auth/me` on load; all data endpoints require auth and are scoped by `req.userId`. Implementation plan: [implementation_plans/authentication.md](implementation_plans/authentication.md).
+- **Authentication:** Backend-managed OAuth (Google, GitHub) with server-side session cookies (express-session, Valkey store via connect-redis). Session is HttpOnly, Secure in production, SameSite=Lax. No JWTs in localStorage. SPA calls `GET /api/auth/me` on load; all data endpoints require auth and are scoped by `req.userId`. Implementation plan: [implementation_plans/authentication.md](implementation_plans/authentication.md).
 - **File parsing on backend:** Files are uploaded raw, parsed server-side using `@sports-alliance/sports-lib`, then discarded. No file storage.
 - **Relational stats storage:** Event and activity statistics stored in separate tables (`event_stats`, `activity_stats`) with one row per stat type, not as JSON blobs.
 - **Timestamped stream data:** Stream data stored relationally in `stream_data_points` with `time_ms` (BIGINT UTC milliseconds) and `sequence_index` for ordering.
@@ -287,6 +287,9 @@ Full request/response details: [docs/ARCHITECTURE.md](docs/ARCHITECTURE.md).
   - `DB_DATABASE` - Database name (default: openfitlab)
   - `UPLOAD_DIR` - Upload directory (default: `backend/uploads/`)
   - `SESSION_SECRET` - **Required** for session signing. Generate with `openssl rand -hex 32`. No default; server refuses to start if missing or too short.
+  - `VALKEY_HOST` - Valkey hostname (default: localhost, or `valkey` in Docker). Sessions stored in Valkey.
+  - `VALKEY_PORT` - Valkey port (default: 6379)
+  - `VALKEY_URL` - Optional full Valkey URL (overrides host/port)
   - `OAUTH_CALLBACK_URL` - Base URL for OAuth callbacks (e.g. `http://localhost:3000` in dev or `https://your-domain.com` in production). Used to build redirect_uri for providers.
   - `GOOGLE_CLIENT_ID`, `GOOGLE_CLIENT_SECRET` - Google OAuth (optional; if set, Google sign-in is enabled)
   - `GITHUB_CLIENT_ID`, `GITHUB_CLIENT_SECRET` - GitHub OAuth (optional; if set, GitHub sign-in is enabled)

--- a/Makefile
+++ b/Makefile
@@ -2,6 +2,6 @@
 # The API runs db.initializeSchema() on startup, so the schema is applied to the fresh DB.
 .PHONY: db-reset
 db-reset:
-	docker compose down -v db
+	docker compose down -v db valkey
 	docker compose up -d
 	docker-compose restart api

--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -11,9 +11,9 @@
         "@dr.pogodin/csurf": "^1.16.8",
         "@sports-alliance/sports-lib": "^9.0.0",
         "@xmldom/xmldom": "^0.9.0",
+        "connect-redis": "^7.1.1",
         "cors": "^2.8.5",
         "express": "^5.2.1",
-        "express-mysql-session": "^3.0.3",
         "express-rate-limit": "^8.2.1",
         "express-session": "^1.19.0",
         "helmet": "^8.1.0",
@@ -21,7 +21,8 @@
         "mysql2": "^3.11.0",
         "passport": "^0.7.0",
         "passport-github2": "^0.1.12",
-        "passport-google-oauth20": "^2.0.0"
+        "passport-google-oauth20": "^2.0.0",
+        "redis": "^4.6.0"
       },
       "devDependencies": {
         "@eslint/js": "^10.0.1",
@@ -265,6 +266,65 @@
       "license": "MIT",
       "dependencies": {
         "@noble/hashes": "^1.1.5"
+      }
+    },
+    "node_modules/@redis/bloom": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@redis/bloom/-/bloom-1.2.0.tgz",
+      "integrity": "sha512-HG2DFjYKbpNmVXsa0keLHp/3leGJz1mjh09f2RLGGLQZzSHpkmZWuwJbAvo3QcRY8p80m5+ZdXZdYOSBLlp7Cg==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@redis/client": "^1.0.0"
+      }
+    },
+    "node_modules/@redis/client": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/@redis/client/-/client-1.6.1.tgz",
+      "integrity": "sha512-/KCsg3xSlR+nCK8/8ZYSknYxvXHwubJrU82F3Lm1Fp6789VQ0/3RJKfsmRXjqfaTA++23CvC3hqmqe/2GEt6Kw==",
+      "license": "MIT",
+      "dependencies": {
+        "cluster-key-slot": "1.1.2",
+        "generic-pool": "3.9.0",
+        "yallist": "4.0.0"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/@redis/graph": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@redis/graph/-/graph-1.1.1.tgz",
+      "integrity": "sha512-FEMTcTHZozZciLRl6GiiIB4zGm5z5F3F6a6FZCyrfxdKOhFlGkiAqlexWMBzCi4DcRoyiOsuLfW+cjlGWyExOw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@redis/client": "^1.0.0"
+      }
+    },
+    "node_modules/@redis/json": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/@redis/json/-/json-1.0.7.tgz",
+      "integrity": "sha512-6UyXfjVaTBTJtKNG4/9Z8PSpKE6XgSyEb8iwaqDcy+uKrd/DGYHTWkUdnQDyzm727V7p21WUMhsqz5oy65kPcQ==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@redis/client": "^1.0.0"
+      }
+    },
+    "node_modules/@redis/search": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@redis/search/-/search-1.2.0.tgz",
+      "integrity": "sha512-tYoDBbtqOVigEDMAcTGsRlMycIIjwMCgD8eR2t0NANeQmgK/lvxNAvYyb6bZDD4frHRhIHkJu2TBRvB0ERkOmw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@redis/client": "^1.0.0"
+      }
+    },
+    "node_modules/@redis/time-series": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@redis/time-series/-/time-series-1.1.0.tgz",
+      "integrity": "sha512-c1Q99M5ljsIuc4YdaCwfUEXsofakb9c8+Zse2qxTadu8TalLXuAESzLvFAvNVbkmSlvlzIQOLpBCmWI9wTOt+g==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@redis/client": "^1.0.0"
       }
     },
     "node_modules/@sports-alliance/sports-lib": {
@@ -559,6 +619,15 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/cluster-key-slot": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/cluster-key-slot/-/cluster-key-slot-1.1.2.tgz",
+      "integrity": "sha512-RMr0FhtfXemyinomL4hrWcYJxmX6deFdCxpJzhDttxgO1+bcCnkk+9drydLVDmAMG7NE6aN/fl4F7ucU/90gAA==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/combined-stream": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
@@ -595,6 +664,18 @@
         "inherits": "^2.0.3",
         "readable-stream": "^3.0.2",
         "typedarray": "^0.0.6"
+      }
+    },
+    "node_modules/connect-redis": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/connect-redis/-/connect-redis-7.1.1.tgz",
+      "integrity": "sha512-M+z7alnCJiuzKa8/1qAYdGUXHYfDnLolOGAUjOioB07pP39qxjG+X9ibsud7qUBc4jMV5Mcy3ugGv8eFcgamJQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=16"
+      },
+      "peerDependencies": {
+        "express-session": ">=1"
       }
     },
     "node_modules/content-disposition": {
@@ -1165,70 +1246,6 @@
         "url": "https://opencollective.com/express"
       }
     },
-    "node_modules/express-mysql-session": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/express-mysql-session/-/express-mysql-session-3.0.3.tgz",
-      "integrity": "sha512-sEYrzFrOs3er+Ie/uk1dt93qz4AQ9SU1mpJJ0HPs0MJ4t4hE9AcDRNq0sZQUwy2F/SbXusBt1E5+FY6KzSqXNg==",
-      "license": "MIT",
-      "dependencies": {
-        "debug": "4.3.4",
-        "mysql2": "3.10.2"
-      }
-    },
-    "node_modules/express-mysql-session/node_modules/debug": {
-      "version": "4.3.4",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
-      "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
-      "license": "MIT",
-      "dependencies": {
-        "ms": "2.1.2"
-      },
-      "engines": {
-        "node": ">=6.0"
-      },
-      "peerDependenciesMeta": {
-        "supports-color": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/express-mysql-session/node_modules/iconv-lite": {
-      "version": "0.6.3",
-      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
-      "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
-      "license": "MIT",
-      "dependencies": {
-        "safer-buffer": ">= 2.1.2 < 3.0.0"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/express-mysql-session/node_modules/ms": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
-      "license": "MIT"
-    },
-    "node_modules/express-mysql-session/node_modules/mysql2": {
-      "version": "3.10.2",
-      "resolved": "https://registry.npmjs.org/mysql2/-/mysql2-3.10.2.tgz",
-      "integrity": "sha512-KCXPEvAkO0RcHPr362O5N8tFY2fXvbjfkPvRY/wGumh4EOemo9Hm5FjQZqv/pCmrnuxGu5OxnSENG0gTXqKMgQ==",
-      "license": "MIT",
-      "dependencies": {
-        "denque": "^2.1.0",
-        "generate-function": "^2.3.1",
-        "iconv-lite": "^0.6.3",
-        "long": "^5.2.1",
-        "lru-cache": "^8.0.0",
-        "named-placeholders": "^1.1.3",
-        "seq-queue": "^0.0.5",
-        "sqlstring": "^2.3.2"
-      },
-      "engines": {
-        "node": ">= 8.0"
-      }
-    },
     "node_modules/express-rate-limit": {
       "version": "8.2.1",
       "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.2.1.tgz",
@@ -1541,6 +1558,15 @@
       "license": "MIT",
       "dependencies": {
         "is-property": "^1.0.2"
+      }
+    },
+    "node_modules/generic-pool": {
+      "version": "3.9.0",
+      "resolved": "https://registry.npmjs.org/generic-pool/-/generic-pool-3.9.0.tgz",
+      "integrity": "sha512-hymDOu5B53XvN4QT9dBmZxPX4CWhBPPLguTZ9MMFeFa/Kg0xWVfylOVNlJji/E7yTZWFd/q9GO5TxDLq156D7g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4"
       }
     },
     "node_modules/geolib": {
@@ -1930,15 +1956,6 @@
       "resolved": "https://registry.npmjs.org/lowpassf/-/lowpassf-0.5.0.tgz",
       "integrity": "sha512-pjMXuHlZIP/2lF+IGQ7GKQk2OIDCeynO9Ot9C0RlOH4PfpJ/tjKDfGsl//AS7SgbD13di0QxzL/mO3s10tkfWA==",
       "license": "MIT"
-    },
-    "node_modules/lru-cache": {
-      "version": "8.0.5",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-8.0.5.tgz",
-      "integrity": "sha512-MhWWlVnuab1RG5/zMRRcVGXZLCXrZTgfwMikgzCegsPnG62yDQo5JnqKkrK4jO5iKqDAZGItAqN5CtKBCBWRUA==",
-      "license": "ISC",
-      "engines": {
-        "node": ">=16.14"
-      }
     },
     "node_modules/lru.min": {
       "version": "1.1.4",
@@ -2517,6 +2534,23 @@
         "node": ">= 6"
       }
     },
+    "node_modules/redis": {
+      "version": "4.7.1",
+      "resolved": "https://registry.npmjs.org/redis/-/redis-4.7.1.tgz",
+      "integrity": "sha512-S1bJDnqLftzHXHP8JsT5II/CtHWQrASX5K96REjWjlmWKrviSOLWmM7QnRLstAWsu1VBBV1ffV6DzCvxNP0UJQ==",
+      "license": "MIT",
+      "workspaces": [
+        "./packages/*"
+      ],
+      "dependencies": {
+        "@redis/bloom": "1.2.0",
+        "@redis/client": "1.6.1",
+        "@redis/graph": "1.1.1",
+        "@redis/json": "1.0.7",
+        "@redis/search": "1.2.0",
+        "@redis/time-series": "1.1.0"
+      }
+    },
     "node_modules/regexp-tree": {
       "version": "0.1.27",
       "resolved": "https://registry.npmjs.org/regexp-tree/-/regexp-tree-0.1.27.tgz",
@@ -2633,11 +2667,6 @@
         "type": "opencollective",
         "url": "https://opencollective.com/express"
       }
-    },
-    "node_modules/seq-queue": {
-      "version": "0.0.5",
-      "resolved": "https://registry.npmjs.org/seq-queue/-/seq-queue-0.0.5.tgz",
-      "integrity": "sha512-hr3Wtp/GZIc/6DAGPDcV4/9WoZhjrkXsi5B/07QgX8tsdc6ilr7BFM6PM6rbdAX1kFSDYeZGLipIZZKyQP0O5Q=="
     },
     "node_modules/serve-static": {
       "version": "2.2.1",
@@ -2772,15 +2801,6 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/mysqljs/sql-escaper?sponsor=1"
-      }
-    },
-    "node_modules/sqlstring": {
-      "version": "2.3.3",
-      "resolved": "https://registry.npmjs.org/sqlstring/-/sqlstring-2.3.3.tgz",
-      "integrity": "sha512-qC9iz2FlN7DQl3+wjwn3802RTyjCx7sDvfQEXchwa6CWOx07/WVfh91gBmQ9fahw8snwGEWU3xGzOt4tFyHLxg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.6"
       }
     },
     "node_modules/statuses": {
@@ -3068,6 +3088,12 @@
       "engines": {
         "node": ">=8.0"
       }
+    },
+    "node_modules/yallist": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
+      "license": "ISC"
     },
     "node_modules/yocto-queue": {
       "version": "0.1.0",

--- a/backend/package.json
+++ b/backend/package.json
@@ -20,9 +20,9 @@
   "dependencies": {
     "@dr.pogodin/csurf": "^1.16.8",
     "@sports-alliance/sports-lib": "^9.0.0",
+    "connect-redis": "^7.1.1",
     "cors": "^2.8.5",
     "express": "^5.2.1",
-    "express-mysql-session": "^3.0.3",
     "express-rate-limit": "^8.2.1",
     "express-session": "^1.19.0",
     "helmet": "^8.1.0",
@@ -31,6 +31,7 @@
     "passport": "^0.7.0",
     "passport-github2": "^0.1.12",
     "passport-google-oauth20": "^2.0.0",
+    "redis": "^4.6.0",
     "@xmldom/xmldom": "^0.9.0"
   },
   "devDependencies": {

--- a/backend/sql/schema.sql
+++ b/backend/sql/schema.sql
@@ -1,8 +1,9 @@
 -- OpenFitLab database schema
 --
--- Tables: users, user_identities, sessions, events, event_stats, activities, activity_stats,
---         streams, stream_data_points, comparisons, comparison_events
--- Applied on API startup via db.initializeSchema(). No migrations; schema changes require DB recreate.
+-- Tables: users, user_identities, events, event_stats, activities, activity_stats,
+--         streams, stream_data_points, comparisons, comparison_event_activities
+-- Sessions are stored in Valkey (not in DB). Applied on API startup via db.initializeSchema().
+-- No migrations; schema changes require DB recreate.
 -- Foreign keys with ON DELETE CASCADE so deleting a user or event removes all related rows.
 
 CREATE TABLE IF NOT EXISTS users (
@@ -26,15 +27,6 @@ CREATE TABLE IF NOT EXISTS user_identities (
   UNIQUE KEY uk_provider_identity (provider, provider_user_id),
   INDEX idx_user_id (user_id),
   CONSTRAINT fk_identity_user FOREIGN KEY (user_id) REFERENCES users (id) ON DELETE CASCADE
-)
-DEFAULT CHARSET = utf8mb4
-COLLATE = utf8mb4_unicode_ci;
-
-CREATE TABLE IF NOT EXISTS sessions (
-  session_id VARCHAR(128) PRIMARY KEY,
-  expires BIGINT UNSIGNED NOT NULL,
-  data MEDIUMTEXT,
-  INDEX idx_expires (expires)
 )
 DEFAULT CHARSET = utf8mb4
 COLLATE = utf8mb4_unicode_ci;

--- a/backend/src/config.js
+++ b/backend/src/config.js
@@ -15,6 +15,9 @@ const {
   DB_PASSWORD,
   DB_DATABASE,
   SESSION_SECRET,
+  VALKEY_HOST,
+  VALKEY_PORT,
+  VALKEY_URL,
   OAUTH_CALLBACK_URL,
   GOOGLE_CLIENT_ID,
   GOOGLE_CLIENT_SECRET,
@@ -83,6 +86,22 @@ const session = {
   cookieSecure: isProduction,
 };
 
+const valkeyHost = VALKEY_HOST != null && VALKEY_HOST !== '' ? String(VALKEY_HOST) : 'localhost';
+const valkeyPort =
+  VALKEY_PORT != null && VALKEY_PORT !== ''
+    ? (() => {
+        const n = parseInt(String(VALKEY_PORT), 10);
+        return Number.isNaN(n) ? 6379 : Math.max(1, Math.min(65535, n));
+      })()
+    : 6379;
+const valkeyUrl = VALKEY_URL != null && VALKEY_URL !== '' ? String(VALKEY_URL) : null;
+
+const valkey = {
+  url: valkeyUrl,
+  host: valkeyHost,
+  port: valkeyPort,
+};
+
 const oauthCallbackUrl = OAUTH_CALLBACK_URL || 'http://localhost:3000';
 
 const googleClientId = GOOGLE_CLIENT_ID != null ? String(GOOGLE_CLIENT_ID) : '';
@@ -126,6 +145,7 @@ const config = {
     oauthRedirectBase,
   },
   session,
+  valkey,
   oauth,
   rateLimit,
 };

--- a/backend/src/index.js
+++ b/backend/src/index.js
@@ -62,11 +62,11 @@ async function start() {
   if (!fs.existsSync(uploadDir)) fs.mkdirSync(uploadDir, { recursive: true });
   await db.initializeSchema();
 
-  // Session + Passport (needs DB pool for session store)
+  // Session + Passport (session store: Valkey via connect-redis)
   const { createSessionMiddleware } = require('./middleware/session');
   const { configurePassport } = require('./middleware/passport');
-  const pool = await db.getPool();
-  app.use(createSessionMiddleware(pool));
+  const sessionMiddleware = await createSessionMiddleware();
+  app.use(sessionMiddleware);
   const passport = configurePassport();
   app.use(passport.initialize());
   app.use(passport.session());

--- a/backend/src/middleware/session.js
+++ b/backend/src/middleware/session.js
@@ -1,27 +1,26 @@
 const session = require('express-session');
-const MySQLStore = require('express-mysql-session')(session);
+const RedisStore = require('connect-redis').default;
+const { createClient } = require('redis');
 const config = require('../config');
 
 /**
- * Creates the session middleware backed by the existing MariaDB pool.
- * @param {object} pool - mysql2/promise pool instance
- * @returns {function} Express session middleware
+ * Creates the session middleware backed by Valkey (Redis-protocol compatible).
+ * Connects to Valkey using config.valkey (url or host/port).
+ * @returns {Promise<function>} Promise that resolves to Express session middleware
  */
-function createSessionMiddleware(pool) {
-  const store = new MySQLStore(
-    {
-      createDatabaseTable: false,
-      schema: {
-        tableName: 'sessions',
-        columnNames: {
-          session_id: 'session_id',
-          expires: 'expires',
-          data: 'data',
-        },
-      },
-    },
-    pool
-  );
+async function createSessionMiddleware() {
+  const { valkey: valkeyConfig } = config;
+  const clientOptions = valkeyConfig.url
+    ? { url: valkeyConfig.url }
+    : { socket: { host: valkeyConfig.host, port: valkeyConfig.port } };
+
+  const client = createClient(clientOptions);
+  await client.connect();
+
+  const store = new RedisStore({
+    client,
+    prefix: 'ofl:sess:',
+  });
 
   // secure and maxAge set; domain omitted by design (same-origin). See AGENTS.md Security.
   return session({

--- a/backend/test/unit/config.test.js
+++ b/backend/test/unit/config.test.js
@@ -34,6 +34,7 @@ describe('config', () => {
     ok(config.db);
     ok(config.server);
     ok(config.session);
+    ok(config.valkey);
     ok(config.oauth);
     ok(config.rateLimit);
   });
@@ -57,6 +58,12 @@ describe('config', () => {
     strictEqual(typeof config.session.secret, 'string');
     strictEqual(config.session.secret.length >= 32, true);
     strictEqual(typeof config.session.cookieSecure, 'boolean');
+  });
+
+  it('valkey has host, port, and url', () => {
+    strictEqual(typeof config.valkey.host, 'string');
+    strictEqual(typeof config.valkey.port, 'number');
+    strictEqual(config.valkey.url === null || typeof config.valkey.url === 'string', true);
   });
 
   it('rateLimit.api has default max and windowMs', () => {

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -17,6 +17,17 @@ services:
       retries: 5
       start_period: 30s
 
+  valkey:
+    image: valkey/valkey:8-alpine
+    volumes:
+      - valkey_data:/data
+    healthcheck:
+      test: ["CMD", "valkey-cli", "ping"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+      start_period: 5s
+
   api:
     image: node:24-alpine
     working_dir: /app
@@ -29,6 +40,8 @@ services:
       DB_PASSWORD: ${MARIADB_PASSWORD:-qspass}
       DB_DATABASE: ${MARIADB_DATABASE:-openfitlab}
       SESSION_SECRET: ${SESSION_SECRET:?SESSION_SECRET is required}
+      VALKEY_HOST: valkey
+      VALKEY_PORT: 6379
       GOOGLE_CLIENT_ID: ${GOOGLE_CLIENT_ID:-}
       GOOGLE_CLIENT_SECRET: ${GOOGLE_CLIENT_SECRET:-}
       GITHUB_CLIENT_ID: ${GITHUB_CLIENT_ID:-}
@@ -36,6 +49,8 @@ services:
       OAUTH_CALLBACK_URL: ${OAUTH_CALLBACK_URL:-http://localhost:3000}
     depends_on:
       db:
+        condition: service_healthy
+      valkey:
         condition: service_healthy
     volumes:
       - ./backend:/app
@@ -71,3 +86,4 @@ services:
 
 volumes:
   db_data:
+  valkey_data:


### PR DESCRIPTION
**Changes:**
- Add Valkey service to docker-compose (valkey/valkey:8-alpine) with healthcheck and volume
- Replace express-mysql-session with connect-redis + redis client (Valkey-compatible)
- Add VALKEY_HOST, VALKEY_PORT, VALKEY_URL config; session middleware connects to Valkey
- Remove sessions table from schema; sessions stored in Valkey with prefix ofl:sess:
- Make createSessionMiddleware async (connects client before returning middleware)
- Update config tests for valkey; document Valkey in AGENTS.md
- Makefile db-reset: down valkey volume with db for full reset