### PR TITLE
Fix frontend build warnings (client import, chunk size)

### DIFF
--- a/frontend/src/App.svelte
+++ b/frontend/src/App.svelte
@@ -1,9 +1,8 @@
 <script lang="ts">
   import Router, { location } from 'svelte-spa-router';
+  import { wrap } from 'svelte-spa-router/wrap';
   import Dashboard from './routes/dashboard.svelte';
-  import EventDetail from './routes/event-detail.svelte';
   import Comparisons from './routes/comparisons.svelte';
-  import ComparisonView from './routes/comparison-view.svelte';
   import Account from './routes/account.svelte';
   import LoginPage from './routes/login.svelte';
   import Privacy from './routes/privacy.svelte';
@@ -17,9 +16,16 @@
 
   const routes = {
     '/': Dashboard,
-    '/event/:id': EventDetail,
+    // svelte-spa-router wrap() expects Svelte 4 ComponentType; we use Svelte 5. Cast to satisfy typecheck.
+    '/event/:id': wrap({
+      asyncComponent: () => import('./routes/event-detail.svelte'),
+      loadingComponent: LoadingSpinner,
+    } as never),
     '/comparisons': Comparisons,
-    '/compare/:id': ComparisonView,
+    '/compare/:id': wrap({
+      asyncComponent: () => import('./routes/comparison-view.svelte'),
+      loadingComponent: LoadingSpinner,
+    } as never),
     '/account': Account,
     '/privacy': Privacy,
     '*': NotFound,

--- a/frontend/src/lib/stores/auth.svelte.ts
+++ b/frontend/src/lib/stores/auth.svelte.ts
@@ -63,8 +63,13 @@ export async function checkAuth(): Promise<void> {
 
 export async function logout(): Promise<void> {
   try {
-    const { apiFetch } = await import('../api/client');
-    await apiFetch('/api/auth/logout', { method: 'POST' });
+    const headers: HeadersInit = {};
+    if (state.csrfToken) headers['CSRF-Token'] = state.csrfToken;
+    await fetch('/api/auth/logout', {
+      method: 'POST',
+      credentials: 'include',
+      headers,
+    });
   } finally {
     state.user = null;
     state.csrfToken = null;

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -8,6 +8,18 @@ const __dirname = path.dirname(fileURLToPath(import.meta.url))
 
 export default defineConfig({
   plugins: [tailwindcss(), svelte()],
+  build: {
+    chunkSizeWarningLimit: 1100, // maplibre-gl vendor chunk is ~1 MB; app chunks are under 500 kB
+    rollupOptions: {
+      output: {
+        manualChunks(id) {
+          if (id.includes('node_modules/maplibre-gl')) return 'maplibre'
+          if (id.includes('node_modules/svelte-maplibre-gl')) return 'maplibre'
+          if (id.includes('node_modules/uplot')) return 'uplot'
+        },
+      },
+    },
+  },
   resolve: {
     alias: {
       $docs: path.resolve(__dirname, '../docs'),


### PR DESCRIPTION
**Changes:**
 * In auth store logout(), call fetch with credentials and CSRF-Token instead of dynamic import of api client (removes mixed static/dynamic import warning)
 * Lazy-load event-detail and comparison-view routes via svelte-spa-router wrap() with LoadingSpinner placeholder
 * Add Vite manualChunks for maplibre-gl and uplot; set chunkSizeWarningLimit to 1100 for maplibre vendor chunk

