### PR TITLE
Show privacy policy in modal on pending signup; keep it viewable when…

### DIFF
--- a/frontend/src/App.svelte
+++ b/frontend/src/App.svelte
@@ -52,6 +52,12 @@
     '*': NotFound,
   };
 
+  const pendingSignupRoutes = {
+    '/': TermsAcceptance,
+    '/privacy': Privacy,
+    '*': TermsAcceptance,
+  };
+
   let sidebarCollapsed = $state(localStorage.getItem('sidebarCollapsed') === 'true');
 
   $effect(() => {
@@ -392,7 +398,7 @@
           <LoadingSpinner />
         </div>
       {:else if authState.pendingSignup}
-        <TermsAcceptance />
+        <Router routes={pendingSignupRoutes} />
       {:else if !authState.user}
         <Router routes={unauthenticatedRoutes} />
       {:else}

--- a/frontend/src/routes/__tests__/App.test.ts
+++ b/frontend/src/routes/__tests__/App.test.ts
@@ -59,6 +59,7 @@ describe('App', () => {
     mockAuthState.user = null;
     mockAuthState.authLoading = true;
     mockAuthState.authChecked = false;
+    mockAuthState.pendingSignup = false;
     getLocationStore()?.set('/');
     storage['sidebarCollapsed'] = '';
     vi.spyOn(Storage.prototype, 'getItem').mockImplementation(
@@ -96,6 +97,17 @@ describe('App', () => {
       expect(screen.getByText('Continue with GitHub')).toBeInTheDocument();
       expect(screen.getByTestId('app-router')).toBeInTheDocument();
       expect(document.querySelectorAll('svg.animate-spin').length).toBe(0);
+    });
+
+    it('shows Router when pending signup so privacy page is reachable', async () => {
+      mockAuthState.authLoading = false;
+      mockAuthState.user = null;
+      mockAuthState.pendingSignup = true;
+      render(App);
+      await waitFor(() => {
+        expect(screen.getByTestId('app-router')).toBeInTheDocument();
+      });
+      expect(screen.queryByText('Welcome to OpenFitLab')).not.toBeInTheDocument();
     });
 
     it('shows Router and sidebar nav when authenticated', async () => {

--- a/frontend/src/routes/__tests__/privacy.test.ts
+++ b/frontend/src/routes/__tests__/privacy.test.ts
@@ -1,0 +1,43 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen } from '@testing-library/svelte';
+import Privacy from '../privacy.svelte';
+
+const { mockAuthState } = vi.hoisted(() => ({
+  mockAuthState: { pendingSignup: true },
+}));
+
+vi.mock('../../lib/stores/auth.svelte', () => ({
+  state: mockAuthState,
+}));
+
+vi.mock('../../lib/config/privacy.js', () => ({
+  privacyConfig: {
+    lastUpdated: '2024-01-01',
+    region: 'United Kingdom',
+    email: null,
+    hasAnalytics: false,
+    analyticsConfig: null,
+  },
+}));
+
+describe('Privacy', () => {
+  beforeEach(() => {
+    mockAuthState.pendingSignup = true;
+  });
+
+  it('shows Back to terms link when pendingSignup and not embedded in modal', () => {
+    render(Privacy, { props: { embeddedInModal: false } });
+    expect(screen.getByRole('link', { name: 'Back to terms' })).toBeInTheDocument();
+  });
+
+  it('hides Back to terms link when embeddedInModal is true', () => {
+    render(Privacy, { props: { embeddedInModal: true } });
+    expect(screen.queryByRole('link', { name: 'Back to terms' })).not.toBeInTheDocument();
+  });
+
+  it('renders Privacy Policy heading and content', () => {
+    render(Privacy, { props: {} });
+    expect(screen.getByRole('heading', { name: 'Privacy Policy' })).toBeInTheDocument();
+    expect(screen.getByText(/Last Updated:/)).toBeInTheDocument();
+  });
+});

--- a/frontend/src/routes/__tests__/terms-acceptance.test.ts
+++ b/frontend/src/routes/__tests__/terms-acceptance.test.ts
@@ -1,0 +1,93 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent, waitFor, within } from '@testing-library/svelte';
+import TermsAcceptance from '../terms-acceptance.svelte';
+
+const { mockCompleteSignup, mockDeclineSignup, mockCheckAuth, mockPush, mockAuthState } =
+  vi.hoisted(() => {
+    return {
+      mockCompleteSignup: vi.fn(),
+      mockDeclineSignup: vi.fn(),
+      mockCheckAuth: vi.fn(),
+      mockPush: vi.fn(),
+      mockAuthState: {
+        user: null as { id: string; displayName: string | null; avatarUrl: string | null } | null,
+        pendingSignup: true,
+        pendingProfile: { displayName: 'Test User', avatarUrl: null } as {
+          displayName: string | null;
+          avatarUrl: string | null;
+        } | null,
+      },
+    };
+  });
+
+vi.mock('../../lib/api/auth', () => ({
+  completeSignup: () => mockCompleteSignup(),
+  declineSignup: () => mockDeclineSignup(),
+}));
+
+vi.mock('../../lib/stores/auth.svelte', () => ({
+  state: mockAuthState,
+  checkAuth: (...args: unknown[]) => mockCheckAuth(...args),
+}));
+
+vi.mock('svelte-spa-router', () => ({
+  push: (path: string) => mockPush(path),
+}));
+
+describe('TermsAcceptance', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockAuthState.pendingSignup = true;
+    mockAuthState.pendingProfile = { displayName: 'Test User', avatarUrl: null };
+  });
+
+  it('renders welcome and Privacy Policy button', () => {
+    render(TermsAcceptance);
+    expect(screen.getByText('Welcome to OpenFitLab')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Privacy Policy' })).toBeInTheDocument();
+  });
+
+  it('opens privacy modal when Privacy Policy button is clicked', async () => {
+    render(TermsAcceptance);
+    expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+
+    await fireEvent.click(screen.getByRole('button', { name: 'Privacy Policy' }));
+
+    await waitFor(() => {
+      expect(screen.getByRole('dialog')).toBeInTheDocument();
+    });
+    const dialog = screen.getByRole('dialog');
+    expect(dialog).toHaveAttribute('aria-modal', 'true');
+    expect(dialog.querySelector('#privacy-modal-title')).toHaveTextContent('Privacy Policy');
+    expect(within(dialog).getByText(/Data Controller:/)).toBeInTheDocument();
+  });
+
+  it('closes modal when Close button is clicked', async () => {
+    render(TermsAcceptance);
+    await fireEvent.click(screen.getByRole('button', { name: 'Privacy Policy' }));
+    await waitFor(() => {
+      expect(screen.getByRole('dialog')).toBeInTheDocument();
+    });
+
+    await fireEvent.click(screen.getByRole('button', { name: 'Close' }));
+
+    await waitFor(() => {
+      expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+    });
+  });
+
+  it('closes modal on Escape key', async () => {
+    render(TermsAcceptance);
+    await fireEvent.click(screen.getByRole('button', { name: 'Privacy Policy' }));
+    await waitFor(() => {
+      expect(screen.getByRole('dialog')).toBeInTheDocument();
+    });
+
+    const dialog = screen.getByRole('dialog');
+    await fireEvent.keyDown(dialog, { key: 'Escape' });
+
+    await waitFor(() => {
+      expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+    });
+  });
+});

--- a/frontend/src/routes/privacy.svelte
+++ b/frontend/src/routes/privacy.svelte
@@ -1,8 +1,19 @@
 <script lang="ts">
   import { privacyConfig } from '../lib/config/privacy.js';
+  import { state as authState } from '../lib/stores/auth.svelte';
+
+  interface Props {
+    embeddedInModal?: boolean;
+  }
+  let { embeddedInModal = false }: Props = $props();
 </script>
 
 <div class="mx-auto max-w-4xl px-4 py-8">
+  {#if authState.pendingSignup && !embeddedInModal}
+    <p class="mb-4 text-sm text-text-secondary">
+      <a href="#/" class="text-accent hover:underline">Back to terms</a>
+    </p>
+  {/if}
   <h1 class="mb-6 text-3xl font-bold text-text-primary">Privacy Policy</h1>
 
   <div class="prose prose-invert max-w-none text-text-primary">

--- a/frontend/src/routes/terms-acceptance.svelte
+++ b/frontend/src/routes/terms-acceptance.svelte
@@ -4,11 +4,22 @@
   import { state as authState, checkAuth } from '../lib/stores/auth.svelte';
   import { privacyConfig } from '../lib/config/privacy.js';
   import { push } from 'svelte-spa-router';
+  import Privacy from './privacy.svelte';
 
   let accepted = $state(false);
   let isSubmitting = $state(false);
   let isDeclining = $state(false);
   let error = $state<string | null>(null);
+  let showPrivacyModal = $state(false);
+  let privacyDialogRef: HTMLDivElement | undefined = $state();
+
+  $effect(() => {
+    if (!showPrivacyModal || !privacyDialogRef) return;
+    const id = requestAnimationFrame(() => {
+      privacyDialogRef?.focus();
+    });
+    return () => cancelAnimationFrame(id);
+  });
 
   async function handleAccept() {
     if (!accepted) return;
@@ -72,7 +83,13 @@
       </h3>
       <p class="text-sm text-text-secondary">
         Please review our
-        <a href="#/privacy" target="_blank" class="text-accent hover:underline">Privacy Policy</a>
+        <button
+          type="button"
+          class="text-accent hover:underline cursor-pointer bg-transparent border-none p-0 font-inherit"
+          onclick={() => (showPrivacyModal = true)}
+        >
+          Privacy Policy
+        </button>
         to understand how we collect, use, and protect your data.
         {#if privacyConfig.email}
           For questions:
@@ -140,3 +157,48 @@
     </div>
   </div>
 </div>
+
+{#if showPrivacyModal}
+  <div
+    bind:this={privacyDialogRef}
+    class="fixed inset-0 z-50 flex items-center justify-center bg-black/50 backdrop-blur-sm p-4"
+    role="dialog"
+    aria-modal="true"
+    aria-labelledby="privacy-modal-title"
+    tabindex="-1"
+    onclick={() => (showPrivacyModal = false)}
+    onkeydown={(e) => {
+      if (e.key === 'Escape') showPrivacyModal = false;
+    }}
+  >
+    <div
+      class="flex max-h-[85vh] w-full max-w-4xl flex-col overflow-hidden rounded-lg border border-border bg-surface shadow-xl"
+      role="presentation"
+      onclick={(e) => e.stopPropagation()}
+      onkeydown={(e) => {
+        if (e.key === 'Escape') {
+          showPrivacyModal = false;
+          e.preventDefault();
+          e.stopPropagation();
+        }
+      }}
+    >
+      <div class="flex shrink-0 items-center justify-between border-b border-border px-4 py-3">
+        <h2 id="privacy-modal-title" class="text-lg font-semibold text-text-primary">
+          Privacy Policy
+        </h2>
+        <button
+          type="button"
+          class="rounded p-1 text-text-secondary hover:bg-card-hover hover:text-text-primary"
+          aria-label="Close"
+          onclick={() => (showPrivacyModal = false)}
+        >
+          <span class="material-icons">close</span>
+        </button>
+      </div>
+      <div class="min-h-0 flex-1 overflow-y-auto">
+        <Privacy embeddedInModal={true} />
+      </div>
+    </div>
+  </div>
+{/if}


### PR DESCRIPTION
… not logged in

**Changes:**
 * Use router when pending signup so #/privacy is reachable (App.svelte: pendingSignupRoutes)
 * On terms-acceptance page, open Privacy Policy in a modal instead of navigating (button triggers modal with Privacy content)
 * Add embeddedInModal prop to Privacy to hide "Back to terms" when shown in modal
 * Add backdrop blur to privacy modal overlay
 * Remove target="_blank" from terms Privacy link (replaced by modal trigger)
 * Add tests for terms-acceptance modal (open/close, dialog content) and Privacy embedded mode