### PR TITLE
Move all SQL from services into repositories

### DIFF
--- a/backend/src/repositories/activity-repository.js
+++ b/backend/src/repositories/activity-repository.js
@@ -2,7 +2,7 @@ const { runQuery } = require('./query-helper');
 const { placeholders } = require('../utils/transforms');
 
 const ACTIVITY_COLUMNS =
-  'a.id, a.event_id, a.name, a.start_date, a.end_date, a.type, a.device_name, a.start_timezone, a.end_timezone';
+  'a.id, a.event_id, a.name, a.start_date, a.end_date, a.type, a.device_name, a.start_timezone, a.end_timezone, a.created_at';
 
 async function insertActivity(row, opts = {}) {
   const sql = `INSERT INTO activities (id, event_id, name, start_date, end_date, type, device_name, start_timezone, end_timezone) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`;

--- a/backend/src/repositories/comparison-repository.js
+++ b/backend/src/repositories/comparison-repository.js
@@ -20,6 +20,27 @@ async function create(id, name, activityRows, settings, opts = {}) {
   }
 }
 
+async function findAllByUserId(userId, opts = {}) {
+  const rows = await runQuery(
+    'SELECT id, folder_id, name, settings, created_at FROM comparisons WHERE user_id = ?',
+    [userId],
+    opts
+  );
+  return Array.isArray(rows) ? rows : [];
+}
+
+async function findEventActivitiesByComparisonIds(comparisonIds, opts = {}) {
+  if (!comparisonIds.length) return [];
+  const rows = await runQuery(
+    `SELECT comparison_id, event_id, activity_id FROM comparison_event_activities WHERE comparison_id IN (${placeholders(
+      comparisonIds.length
+    )})`,
+    comparisonIds,
+    opts
+  );
+  return Array.isArray(rows) ? rows : [];
+}
+
 async function findAll(limit, opts = {}) {
   if (!opts.userId) throw new Error('findAll comparisons requires opts.userId');
   const rows = await runQuery(
@@ -212,6 +233,8 @@ module.exports = {
   create,
   findAll,
   findAllForFolder,
+  findAllByUserId,
+  findEventActivitiesByComparisonIds,
   findById,
   findByEventIds,
   existsById,

--- a/backend/src/repositories/event-repository.js
+++ b/backend/src/repositories/event-repository.js
@@ -92,6 +92,15 @@ async function findManyByIds(ids, opts = {}) {
   return Array.isArray(rows) ? rows : [];
 }
 
+async function findAllByUserId(userId, opts = {}) {
+  const rows = await runQuery(
+    'SELECT id, folder_id, start_date, name, end_date, description, is_merge, src_file_type, created_at FROM events WHERE user_id = ?',
+    [userId],
+    opts
+  );
+  return Array.isArray(rows) ? rows : [];
+}
+
 async function findOverlapping(excludeId, startDate, endDate, limit, opts = {}) {
   if (!opts.userId) throw new Error('findOverlapping requires opts.userId');
   let sql = `
@@ -173,6 +182,7 @@ module.exports = {
   getDateRange,
   findMany,
   findManyByIds,
+  findAllByUserId,
   findOverlapping,
   getStatsByEventIds,
   getStatsByEventId,

--- a/backend/src/repositories/folder-repository.js
+++ b/backend/src/repositories/folder-repository.js
@@ -116,6 +116,43 @@ async function getComparisonCountByFolderId(folderId, opts = {}) {
   return row && row.n != null ? Number(row.n) : 0;
 }
 
+async function findEventIdsByFolderId(folderId, opts = {}) {
+  if (!opts.userId) throw new Error('findEventIdsByFolderId requires opts.userId');
+  const rows = await runQuery(
+    'SELECT id FROM events WHERE folder_id = ? AND user_id = ?',
+    [folderId, opts.userId],
+    opts
+  );
+  return Array.isArray(rows) ? rows.map((r) => r.id) : [];
+}
+
+async function clearEventsFolderId(folderId, opts = {}) {
+  if (!opts.userId) throw new Error('clearEventsFolderId requires opts.userId');
+  await runQuery(
+    'UPDATE events SET folder_id = NULL WHERE folder_id = ? AND user_id = ?',
+    [folderId, opts.userId],
+    opts
+  );
+}
+
+async function clearComparisonsFolderId(folderId, opts = {}) {
+  if (!opts.userId) throw new Error('clearComparisonsFolderId requires opts.userId');
+  await runQuery(
+    'UPDATE comparisons SET folder_id = NULL WHERE folder_id = ? AND user_id = ?',
+    [folderId, opts.userId],
+    opts
+  );
+}
+
+async function deleteComparisonsByFolderId(folderId, opts = {}) {
+  if (!opts.userId) throw new Error('deleteComparisonsByFolderId requires opts.userId');
+  await runQuery(
+    'DELETE FROM comparisons WHERE folder_id = ? AND user_id = ?',
+    [folderId, opts.userId],
+    opts
+  );
+}
+
 module.exports = {
   create,
   findById,
@@ -127,4 +164,8 @@ module.exports = {
   deleteById,
   getEventCountByFolderId,
   getComparisonCountByFolderId,
+  findEventIdsByFolderId,
+  clearEventsFolderId,
+  clearComparisonsFolderId,
+  deleteComparisonsByFolderId,
 };

--- a/backend/src/repositories/stream-repository.js
+++ b/backend/src/repositories/stream-repository.js
@@ -23,6 +23,21 @@ async function insertStreamDataPointsBatch(streamId, dataPoints, opts = {}) {
   }
 }
 
+async function findAllByActivityIds(activityIds, opts = {}) {
+  if (!activityIds.length) return [];
+  if (!opts.userId) throw new Error('findAllByActivityIds requires opts.userId');
+  const sql = `SELECT s.id, s.activity_id, s.event_id, s.type, s.created_at
+     FROM streams s
+     JOIN events e ON e.id = s.event_id AND e.user_id = ?
+     WHERE s.activity_id IN (${placeholders(activityIds.length)})`;
+  const rows = await runQuery(sql, [opts.userId, ...activityIds], opts);
+  return Array.isArray(rows) ? rows : [];
+}
+
+async function findDataPointsByStreamIdsOrdered(streamIds, opts = {}) {
+  return findDataPointsByStreamIds(streamIds, opts);
+}
+
 async function findByActivityAndEvent(activityId, eventId, types, opts = {}) {
   if (!opts.userId) throw new Error('findByActivityAndEvent requires opts.userId');
   let sql =
@@ -53,6 +68,8 @@ async function findDataPointsByStreamIds(streamIds, opts = {}) {
 module.exports = {
   insertStream,
   insertStreamDataPointsBatch,
+  findAllByActivityIds,
+  findDataPointsByStreamIdsOrdered,
   findByActivityAndEvent,
   findDataPointsByStreamIds,
 };

--- a/backend/src/repositories/user-repository.js
+++ b/backend/src/repositories/user-repository.js
@@ -30,6 +30,19 @@ async function findIdentityByProvider(provider, providerUserId, opts = {}) {
 }
 
 /**
+ * Find identities for a user (for export). Excludes profile_data for privacy.
+ * @returns {Array<{ id: string, provider: string, provider_user_id: string, email: string | null, created_at: string }>}
+ */
+async function findIdentitiesByUserId(userId, opts = {}) {
+  const rows = await runQuery(
+    'SELECT id, provider, provider_user_id, email, created_at FROM user_identities WHERE user_id = ?',
+    [userId],
+    opts
+  );
+  return Array.isArray(rows) ? rows : [];
+}
+
+/**
  * Find identities by email (for account linking). Returns distinct user_id rows.
  * @returns {Array<{ user_id: string }>}
  */
@@ -120,6 +133,7 @@ module.exports = {
   findById,
   deleteById,
   findIdentityByProvider,
+  findIdentitiesByUserId,
   findIdentitiesByEmail,
   linkIdentity,
   createFromPendingProfile,

--- a/backend/src/services/account-service.js
+++ b/backend/src/services/account-service.js
@@ -1,6 +1,9 @@
 const userRepository = require('../repositories/user-repository');
-const { runQuery } = require('../repositories/query-helper');
-const { placeholders } = require('../utils/transforms');
+const folderRepository = require('../repositories/folder-repository');
+const eventRepository = require('../repositories/event-repository');
+const activityRepository = require('../repositories/activity-repository');
+const comparisonRepository = require('../repositories/comparison-repository');
+const streamRepository = require('../repositories/stream-repository');
 
 const defaultDb = require('../db');
 
@@ -14,7 +17,7 @@ const defaultDb = require('../db');
  * @returns {Promise<object>}
  */
 async function exportUserData(userId, opts = {}) {
-  const dbOpts = { db: opts.db ?? defaultDb };
+  const dbOpts = { db: opts.db ?? defaultDb, userId };
   const includeStreams = opts.includeStreams === true;
 
   // User profile
@@ -22,105 +25,51 @@ async function exportUserData(userId, opts = {}) {
   if (!user) return null;
 
   // Identities (exclude profile_data for privacy)
-  const identities = await runQuery(
-    'SELECT id, provider, provider_user_id, email, created_at FROM user_identities WHERE user_id = ?',
-    [userId],
-    dbOpts
-  );
-  const identityRows = Array.isArray(identities) ? identities : [];
+  const identityRows = await userRepository.findIdentitiesByUserId(userId, dbOpts);
 
   // Folders
-  const folders = await runQuery(
-    'SELECT id, name, color, pinned, created_at FROM folders WHERE user_id = ? ORDER BY pinned DESC, name ASC',
-    [userId],
-    dbOpts
-  );
-  const folderRows = Array.isArray(folders) ? folders : [];
+  const folderRows = await folderRepository.listAll(userId, dbOpts);
 
   // Events (include folder_id)
-  const events = await runQuery(
-    'SELECT id, folder_id, start_date, name, end_date, description, is_merge, src_file_type, created_at FROM events WHERE user_id = ?',
-    [userId],
-    dbOpts
-  );
-  const eventRows = Array.isArray(events) ? events : [];
+  const eventRows = await eventRepository.findAllByUserId(userId, dbOpts);
   const eventIds = eventRows.map((e) => e.id);
 
   // Event stats (batched)
-  let eventStatRows = [];
-  if (eventIds.length > 0) {
-    const stats = await runQuery(
-      `SELECT event_id, stat_type, value FROM event_stats WHERE event_id IN (${placeholders(eventIds.length)})`,
-      eventIds,
-      dbOpts
-    );
-    eventStatRows = Array.isArray(stats) ? stats : [];
-  }
+  const eventStatRows =
+    eventIds.length > 0 ? await eventRepository.getStatsByEventIds(eventIds, dbOpts) : [];
 
   // Activities (batched)
-  let activityRows = [];
-  if (eventIds.length > 0) {
-    const activities = await runQuery(
-      `SELECT id, event_id, name, start_date, end_date, type, device_name, created_at FROM activities WHERE event_id IN (${placeholders(eventIds.length)})`,
-      eventIds,
-      dbOpts
-    );
-    activityRows = Array.isArray(activities) ? activities : [];
-  }
+  const activityRows =
+    eventIds.length > 0 ? await activityRepository.findManyByEventIds(eventIds, dbOpts) : [];
   const activityIds = activityRows.map((a) => a.id);
 
   // Activity stats (batched)
-  let activityStatRows = [];
-  if (activityIds.length > 0) {
-    const stats = await runQuery(
-      `SELECT activity_id, stat_type, value FROM activity_stats WHERE activity_id IN (${placeholders(activityIds.length)})`,
-      activityIds,
-      dbOpts
-    );
-    activityStatRows = Array.isArray(stats) ? stats : [];
-  }
+  const activityStatRows =
+    activityIds.length > 0
+      ? await activityRepository.getStatsByActivityIds(activityIds, dbOpts)
+      : [];
 
   // Comparisons (include folder_id)
-  const comparisons = await runQuery(
-    'SELECT id, folder_id, name, settings, created_at FROM comparisons WHERE user_id = ?',
-    [userId],
-    dbOpts
-  );
-  const comparisonRows = Array.isArray(comparisons) ? comparisons : [];
+  const comparisonRows = await comparisonRepository.findAllByUserId(userId, dbOpts);
   const comparisonIds = comparisonRows.map((c) => c.id);
 
   // Comparison events/activities (batched)
-  let comparisonEventActivityRows = [];
-  if (comparisonIds.length > 0) {
-    const links = await runQuery(
-      `SELECT comparison_id, event_id, activity_id FROM comparison_event_activities WHERE comparison_id IN (${placeholders(
-        comparisonIds.length
-      )})`,
-      comparisonIds,
-      dbOpts
-    );
-    comparisonEventActivityRows = Array.isArray(links) ? links : [];
-  }
+  const comparisonEventActivityRows =
+    comparisonIds.length > 0
+      ? await comparisonRepository.findEventActivitiesByComparisonIds(comparisonIds, dbOpts)
+      : [];
 
   // Streams metadata (batched) — always included; data points only if includeStreams
   let streamRows = [];
   let streamDataPointRows = [];
   if (activityIds.length > 0) {
-    const streams = await runQuery(
-      `SELECT id, activity_id, event_id, type, created_at FROM streams WHERE activity_id IN (${placeholders(activityIds.length)})`,
-      activityIds,
-      dbOpts
-    );
-    streamRows = Array.isArray(streams) ? streams : [];
-
+    streamRows = await streamRepository.findAllByActivityIds(activityIds, dbOpts);
     if (includeStreams && streamRows.length > 0) {
       const streamIds = streamRows.map((s) => s.id);
-      const points = await runQuery(
-        `SELECT stream_id, time_ms, value, sequence_index FROM stream_data_points WHERE stream_id IN (${placeholders(streamIds.length)}) ORDER BY stream_id, sequence_index ASC, time_ms ASC`,
+      streamDataPointRows = await streamRepository.findDataPointsByStreamIdsOrdered(
         streamIds,
         dbOpts
       );
-      streamDataPointRows = Array.isArray(points) ? points : [];
     }
   }
 

--- a/backend/src/services/folder-service.js
+++ b/backend/src/services/folder-service.js
@@ -3,7 +3,6 @@ const defaultDb = require('../db');
 const folderRepository = require('../repositories/folder-repository');
 const eventRepository = require('../repositories/event-repository');
 const comparisonRepository = require('../repositories/comparison-repository');
-const { runQuery } = require('../repositories/query-helper');
 const { ValidationError } = require('../errors');
 
 const MAX_FOLDERS_PER_USER = 20;
@@ -115,12 +114,7 @@ async function deleteFolder(id, contentsMode, opts = {}) {
   if (contentsMode === 'delete') {
     return db.transaction(async (conn) => {
       const txOpts = { ...repoOpts, conn };
-      const eventRows = await runQuery(
-        'SELECT id FROM events WHERE folder_id = ? AND user_id = ?',
-        [id, opts.userId],
-        txOpts
-      );
-      const eventIds = Array.isArray(eventRows) ? eventRows.map((r) => r.id) : [];
+      const eventIds = await folderRepository.findEventIdsByFolderId(id, txOpts);
       for (const eventId of eventIds) {
         const linked = await comparisonRepository.findByEventIds([eventId], txOpts);
         if (linked.length > 0) {
@@ -131,25 +125,13 @@ async function deleteFolder(id, contentsMode, opts = {}) {
         }
         await eventRepository.deleteById(eventId, txOpts);
       }
-      await runQuery(
-        'DELETE FROM comparisons WHERE folder_id = ? AND user_id = ?',
-        [id, opts.userId],
-        txOpts
-      );
+      await folderRepository.deleteComparisonsByFolderId(id, txOpts);
       return folderRepository.deleteById(id, txOpts);
     });
   }
 
-  await runQuery(
-    'UPDATE events SET folder_id = NULL WHERE folder_id = ? AND user_id = ?',
-    [id, opts.userId],
-    repoOpts
-  );
-  await runQuery(
-    'UPDATE comparisons SET folder_id = NULL WHERE folder_id = ? AND user_id = ?',
-    [id, opts.userId],
-    repoOpts
-  );
+  await folderRepository.clearEventsFolderId(id, repoOpts);
+  await folderRepository.clearComparisonsFolderId(id, repoOpts);
   return folderRepository.deleteById(id, repoOpts);
 }
 

--- a/backend/test/unit/services/account-service.test.js
+++ b/backend/test/unit/services/account-service.test.js
@@ -51,22 +51,22 @@ describe('account-service', () => {
         if (sql.includes('FROM events WHERE')) {
           return [{ id: 'e1', folder_id: null, start_date: 1000, name: 'Run', end_date: 2000, description: null, is_merge: 0, src_file_type: 'fit', created_at: new Date('2025-01-01') }];
         }
-        if (sql.includes('FROM event_stats')) {
+        if (sql.includes('event_stats')) {
           return [{ event_id: 'e1', stat_type: 'distance', value: '100' }];
         }
-        if (sql.includes('FROM activities WHERE')) {
+        if (sql.includes('FROM activities ') && sql.includes('event_id')) {
           return [{ id: 'a1', event_id: 'e1', name: 'Run', start_date: 1000, end_date: 2000, type: 'running', device_name: 'Garmin', created_at: new Date('2025-01-01') }];
         }
-        if (sql.includes('FROM activity_stats')) {
+        if (sql.includes('activity_stats')) {
           return [{ activity_id: 'a1', stat_type: 'hr', value: '150' }];
         }
         if (sql.includes('FROM comparisons WHERE')) {
           return [{ id: 'c1', folder_id: null, name: 'Comp', settings: '{}', created_at: new Date('2025-01-01') }];
         }
-        if (sql.includes('FROM comparison_event_activities')) {
+        if (sql.includes('comparison_event_activities') && sql.includes('comparison_id IN')) {
           return [{ comparison_id: 'c1', event_id: 'e1', activity_id: 'a1' }];
         }
-        if (sql.includes('FROM streams WHERE')) {
+        if (sql.includes('FROM streams ') && sql.includes('activity_id')) {
           return [{ id: 's1', activity_id: 'a1', event_id: 'e1', type: 'heartrate', created_at: new Date('2025-01-01') }];
         }
         return [];
@@ -95,16 +95,16 @@ describe('account-service', () => {
         if (sql.includes('FROM events WHERE')) {
           return [{ id: 'e1', folder_id: null, start_date: 1, name: 'E', end_date: 2, description: null, is_merge: 0, src_file_type: 'fit', created_at: new Date() }];
         }
-        if (sql.includes('FROM event_stats')) return [];
-        if (sql.includes('FROM activities WHERE')) {
+        if (sql.includes('event_stats')) return [];
+        if (sql.includes('FROM activities ') && sql.includes('event_id')) {
           return [{ id: 'a1', event_id: 'e1', name: 'A', start_date: 1, end_date: 2, type: 'run', device_name: null, created_at: new Date() }];
         }
-        if (sql.includes('FROM activity_stats')) return [];
+        if (sql.includes('activity_stats')) return [];
         if (sql.includes('FROM comparisons WHERE')) return [];
-        if (sql.includes('FROM streams WHERE')) {
+        if (sql.includes('FROM streams ') && sql.includes('activity_id')) {
           return [{ id: 's1', activity_id: 'a1', event_id: 'e1', type: 'hr', created_at: new Date() }];
         }
-        if (sql.includes('FROM stream_data_points')) {
+        if (sql.includes('stream_data_points')) {
           return [{ stream_id: 's1', time_ms: 100, value: '72', sequence_index: 0 }];
         }
         return [];
@@ -126,13 +126,13 @@ describe('account-service', () => {
         if (sql.includes('FROM events WHERE')) {
           return [{ id: 'e1', folder_id: null, start_date: 1, name: 'E', end_date: 2, description: null, is_merge: 0, src_file_type: 'fit', created_at: new Date() }];
         }
-        if (sql.includes('FROM event_stats')) return [];
-        if (sql.includes('FROM activities WHERE')) {
+        if (sql.includes('event_stats')) return [];
+        if (sql.includes('FROM activities ') && sql.includes('event_id')) {
           return [{ id: 'a1', event_id: 'e1', name: 'A', start_date: 1, end_date: 2, type: 'run', device_name: null, created_at: new Date() }];
         }
-        if (sql.includes('FROM activity_stats')) return [];
+        if (sql.includes('activity_stats')) return [];
         if (sql.includes('FROM comparisons WHERE')) return [];
-        if (sql.includes('FROM streams WHERE')) {
+        if (sql.includes('FROM streams ') && sql.includes('activity_id')) {
           return [{ id: 's1', activity_id: 'a1', event_id: 'e1', type: 'hr', created_at: new Date() }];
         }
         return [];


### PR DESCRIPTION
**Changes:**
 * Add folder-repository: findEventIdsByFolderId, clearEventsFolderId, clearComparisonsFolderId, deleteComparisonsByFolderId
 * Refactor folder-service to use folder-repository instead of runQuery
 * Add user-repository findIdentitiesByUserId
 * Add event-repository findAllByUserId (getStatsByEventIds already existed)
 * Add activity-repository created_at to ACTIVITY_COLUMNS; use findManyByEventIds/getStatsByActivityIds for export
 * Add comparison-repository findAllByUserId, findEventActivitiesByComparisonIds
 * Add stream-repository findAllByActivityIds, findDataPointsByStreamIdsOrdered
 * Refactor account-service to use repositories for export (no direct runQuery)
 * Update account-service tests to match repository-generated SQL patterns
