### PR TITLE
Backend architectural review: correctness, tests, and docs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -60,6 +60,17 @@
 - Schema is defined in `backend/sql/schema.sql` and applied on startup. There are no migrations; schema changes require DB recreation.
 - Backend configuration must come from `backend/src/config.js`, not direct `process.env` reads elsewhere.
 
+## API contract
+
+The full machine-readable API specification is at [`backend/docs/openapi.yaml`](backend/docs/openapi.yaml) (OpenAPI 3.1).
+
+Key points:
+- All protected endpoints require a valid session cookie (`ofl.sid`).
+- All state-changing requests (POST, PATCH, DELETE) must include the `x-csrf-token` header. Obtain it from `GET /api/auth/me`.
+- Error responses are always `{ "error": "<message>" }`.
+- Missing or unowned resources return `404`, not `403`.
+- Response shapes for events and activities are produced by `mapEventRow` and `mapActivityRow` in `backend/src/utils/transforms.js`.
+
 ## Conventions
 
 ### Backend
@@ -118,6 +129,7 @@ After meaningful refactors, verify:
 |---|---|
 | Technical reference | `docs/ARCHITECTURE.md` |
 | Product intent | `docs/PRD.md` |
+| API contract | `backend/docs/openapi.yaml` |
 | API routes | `backend/src/routes/` |
 | Auth flow | `backend/src/routes/auth.js`, `backend/src/middleware/session.js`, `backend/src/middleware/require-auth.js` |
 | Events and uploads | `backend/src/services/event-query-service.js`, `backend/src/services/event-upload-service.js` |

--- a/backend/docs/openapi.yaml
+++ b/backend/docs/openapi.yaml
@@ -1,0 +1,1332 @@
+openapi: 3.1.0
+info:
+  title: OpenFitLab API
+  version: "1.0"
+  description: |
+    REST API for the OpenFitLab self-hosted fitness activity tracker.
+
+    **Authentication:** All protected endpoints require a valid session cookie
+    (`ofl.sid`). Obtain a session by completing the OAuth flow via
+    `GET /api/auth/google` or `GET /api/auth/github`.
+
+    **CSRF:** All state-changing requests (POST, PATCH, DELETE) must include the
+    `x-csrf-token` header. Obtain the token from `GET /api/auth/me`.
+
+    **Ownership:** All resource endpoints scope data to the authenticated user.
+    A missing or unowned resource returns `404` (not `403`) to avoid leaking existence.
+
+    **Error shape:** All error responses use `{ "error": "<message>" }`.
+
+servers:
+  - url: http://localhost:3000
+    description: Local development
+
+tags:
+  - name: auth
+    description: OAuth login, session management, and account creation
+  - name: events
+    description: Activity event upload, query, and management
+  - name: comparisons
+    description: Saved side-by-side activity comparisons
+  - name: folders
+    description: Named folder organisation for events and comparisons
+  - name: account
+    description: Data export and account deletion
+  - name: meta
+    description: Distinct activity types and device names
+
+# ---------------------------------------------------------------------------
+# Reusable components
+# ---------------------------------------------------------------------------
+components:
+  schemas:
+    Error:
+      type: object
+      required: [error]
+      properties:
+        error:
+          type: string
+          example: Not found
+
+    Stats:
+      type: object
+      description: |
+        Key-value map of stat type to value. Common keys include Distance,
+        Duration, Calories, HeartRateAvg, HeartRateMax, CadenceAvg, PowerAvg,
+        SpeedAvg, ElevationGain. Values may be numbers, strings, or objects
+        depending on stat type.
+      additionalProperties: true
+      example:
+        Distance: 10000
+        Duration: 3600
+        HeartRateAvg: 145
+
+    Activity:
+      type: object
+      required: [id, eventID, stats]
+      properties:
+        id:
+          type: string
+          format: uuid
+        eventID:
+          type: string
+          format: uuid
+        name:
+          type: string
+        startDate:
+          type: integer
+          description: Unix timestamp in milliseconds
+        endDate:
+          type: integer
+          description: Unix timestamp in milliseconds
+        type:
+          type: string
+          example: Running
+        deviceName:
+          type: string
+          example: Garmin Forerunner 245
+        startTimezone:
+          type: string
+          example: UTC
+        endTimezone:
+          type: string
+          example: UTC
+        stats:
+          $ref: "#/components/schemas/Stats"
+
+    Event:
+      type: object
+      required: [id, startDate, name, stats, folderId]
+      properties:
+        id:
+          type: string
+          format: uuid
+        startDate:
+          type: integer
+          description: Unix timestamp in milliseconds
+        endDate:
+          type: integer
+          description: Unix timestamp in milliseconds
+        name:
+          type: string
+        description:
+          type: string
+        isMerge:
+          type: boolean
+        srcFileType:
+          type: string
+          example: tcx
+        startTimezone:
+          type: string
+          example: UTC
+        endTimezone:
+          type: string
+          example: UTC
+        folderId:
+          type: string
+          format: uuid
+          nullable: true
+        stats:
+          $ref: "#/components/schemas/Stats"
+
+    EventDetail:
+      type: object
+      required: [event, activities]
+      properties:
+        event:
+          $ref: "#/components/schemas/Event"
+        activities:
+          type: array
+          items:
+            $ref: "#/components/schemas/Activity"
+
+    ActivityRow:
+      type: object
+      required: [event, activity]
+      properties:
+        event:
+          $ref: "#/components/schemas/Event"
+        activity:
+          $ref: "#/components/schemas/Activity"
+
+    Folder:
+      type: object
+      required: [id, name, color, pinned]
+      properties:
+        id:
+          type: string
+          format: uuid
+        name:
+          type: string
+        color:
+          type: string
+          description: Hex colour code
+          example: "#e74c3c"
+        pinned:
+          type: boolean
+        eventCount:
+          type: integer
+        comparisonCount:
+          type: integer
+        createdAt:
+          type: string
+          format: date-time
+
+    Comparison:
+      type: object
+      required: [id, name, eventIds, activityIds, settings, folderId, mixed, surfaced]
+      properties:
+        id:
+          type: string
+          format: uuid
+        name:
+          type: string
+        eventIds:
+          type: array
+          items:
+            type: string
+            format: uuid
+        activityIds:
+          type: array
+          items:
+            type: string
+            format: uuid
+        settings:
+          type: object
+          nullable: true
+          description: Arbitrary settings blob (e.g. referenceActivityId)
+          properties:
+            referenceActivityId:
+              type: string
+              format: uuid
+              nullable: true
+          additionalProperties: true
+        folderId:
+          type: string
+          format: uuid
+          nullable: true
+        mixed:
+          type: boolean
+          description: True when the comparison references events from more than one folder
+        surfaced:
+          type: boolean
+          description: True when the comparison was returned because it references an event in the queried folder, not because it is directly assigned to it
+        createdAt:
+          type: integer
+          description: Unix timestamp in milliseconds
+
+    StreamDataPoint:
+      type: object
+      required: [timeMs, value, sequenceIndex]
+      properties:
+        timeMs:
+          type: integer
+          description: Absolute timestamp in milliseconds
+        value:
+          description: Stream value (number, array, or object depending on stream type)
+        sequenceIndex:
+          type: integer
+
+    Stream:
+      type: object
+      required: [id, type, activityId, dataPoints]
+      properties:
+        id:
+          type: string
+        type:
+          type: string
+          example: Heart Rate
+        activityId:
+          type: string
+          format: uuid
+        dataPoints:
+          type: array
+          items:
+            $ref: "#/components/schemas/StreamDataPoint"
+
+    UploadResultItem:
+      type: object
+      required: [filename, success]
+      properties:
+        filename:
+          type: string
+        success:
+          type: boolean
+        id:
+          type: string
+          format: uuid
+          description: Present when success is true
+        event:
+          $ref: "#/components/schemas/Event"
+          description: Present when success is true
+        activities:
+          type: array
+          items:
+            $ref: "#/components/schemas/Activity"
+          description: Present when success is true. Activity ids are null in this response.
+        error:
+          type: string
+          description: Present when success is false
+
+    AuthMe:
+      type: object
+      properties:
+        id:
+          type: string
+          format: uuid
+          description: Present when authenticated
+        displayName:
+          type: string
+          nullable: true
+        avatarUrl:
+          type: string
+          nullable: true
+        csrfToken:
+          type: string
+          description: CSRF token — include as x-csrf-token header on all state-changing requests
+        pendingSignup:
+          type: boolean
+          description: Present and true when the user has authenticated via OAuth but has not yet accepted terms
+        profile:
+          type: object
+          description: Present when pendingSignup is true
+          properties:
+            displayName:
+              type: string
+              nullable: true
+            avatarUrl:
+              type: string
+              nullable: true
+
+  parameters:
+    eventId:
+      name: id
+      in: path
+      required: true
+      schema:
+        type: string
+        format: uuid
+      description: Event UUID
+
+    activityId:
+      name: activityId
+      in: path
+      required: true
+      schema:
+        type: string
+        format: uuid
+      description: Activity UUID
+
+    comparisonId:
+      name: id
+      in: path
+      required: true
+      schema:
+        type: string
+        format: uuid
+      description: Comparison UUID
+
+    folderId:
+      name: id
+      in: path
+      required: true
+      schema:
+        type: string
+        format: uuid
+      description: Folder UUID
+
+  responses:
+    Unauthorized:
+      description: Not authenticated
+      content:
+        application/json:
+          schema:
+            $ref: "#/components/schemas/Error"
+    NotFound:
+      description: Resource not found or not owned by the authenticated user
+      content:
+        application/json:
+          schema:
+            $ref: "#/components/schemas/Error"
+    BadRequest:
+      description: Validation error
+      content:
+        application/json:
+          schema:
+            $ref: "#/components/schemas/Error"
+    Forbidden:
+      description: Invalid or missing CSRF token
+      content:
+        application/json:
+          schema:
+            $ref: "#/components/schemas/Error"
+
+  securitySchemes:
+    csrfToken:
+      type: apiKey
+      in: header
+      name: x-csrf-token
+      description: CSRF token obtained from GET /api/auth/me. Required on all state-changing requests (POST, PATCH, DELETE).
+
+# ---------------------------------------------------------------------------
+# Paths
+# ---------------------------------------------------------------------------
+paths:
+
+  # ── Auth ──────────────────────────────────────────────────────────────────
+
+  /api/auth/me:
+    get:
+      tags: [auth]
+      summary: Get current session state
+      description: |
+        Returns the authenticated user and a CSRF token, or a pending-signup
+        profile, or `401` when no valid session exists. Always call this first
+        to obtain the CSRF token required for state-changing requests.
+      responses:
+        "200":
+          description: Authenticated user or pending signup
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/AuthMe"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+
+  /api/auth/google:
+    get:
+      tags: [auth]
+      summary: Initiate Google OAuth flow
+      description: Redirects to Google. Returns 400 if Google OAuth is not configured.
+      responses:
+        "302":
+          description: Redirect to Google authorization endpoint
+        "400":
+          $ref: "#/components/responses/BadRequest"
+
+  /api/auth/google/callback:
+    get:
+      tags: [auth]
+      summary: Google OAuth callback
+      description: |
+        Handles the redirect from Google. On success, creates or resumes a
+        session and redirects to the SPA. On pending signup, stores the profile
+        in session and redirects with `?signup=pending`.
+      responses:
+        "302":
+          description: Redirect to SPA
+
+  /api/auth/github:
+    get:
+      tags: [auth]
+      summary: Initiate GitHub OAuth flow
+      description: Redirects to GitHub. Returns 400 if GitHub OAuth is not configured.
+      responses:
+        "302":
+          description: Redirect to GitHub authorization endpoint
+        "400":
+          $ref: "#/components/responses/BadRequest"
+
+  /api/auth/github/callback:
+    get:
+      tags: [auth]
+      summary: GitHub OAuth callback
+      description: Handles the redirect from GitHub. Behaviour mirrors the Google callback.
+      responses:
+        "302":
+          description: Redirect to SPA
+
+  /api/auth/complete-signup:
+    post:
+      tags: [auth]
+      summary: Accept terms of service and create account
+      description: |
+        Completes a pending signup by creating a user and identity row, then
+        upgrading the session. Requires a pending-signup session (set by an
+        OAuth callback).
+      responses:
+        "201":
+          description: Account created
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/AuthMe"
+        "400":
+          $ref: "#/components/responses/BadRequest"
+
+  /api/auth/decline-signup:
+    post:
+      tags: [auth]
+      summary: Decline terms of service
+      description: Destroys the pending-signup session without creating an account.
+      responses:
+        "200":
+          description: Session destroyed
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  ok:
+                    type: boolean
+
+  /api/auth/logout:
+    post:
+      tags: [auth]
+      summary: Log out
+      description: Destroys the current session and clears the session cookie.
+      security:
+        - csrfToken: []
+      responses:
+        "200":
+          description: Logged out
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  ok:
+                    type: boolean
+
+  # ── Events ────────────────────────────────────────────────────────────────
+
+  /api/events:
+    get:
+      tags: [events]
+      summary: List events
+      description: Returns enriched events (with activities and stats) in reverse-chronological order.
+      parameters:
+        - name: startDate
+          in: query
+          schema:
+            type: integer
+          description: Filter events with start_date >= startDate (ms)
+        - name: endDate
+          in: query
+          schema:
+            type: integer
+          description: Filter events with start_date <= endDate (ms)
+        - name: limit
+          in: query
+          schema:
+            type: integer
+            default: 50
+            maximum: 200
+        - name: folderId
+          in: query
+          schema:
+            type: string
+          description: |
+            Filter by folder. Use `unfiled` for events with no folder,
+            `all` or omit for all events, or a UUID for a specific folder.
+      responses:
+        "200":
+          description: Array of enriched events
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: "#/components/schemas/Event"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+
+    post:
+      tags: [events]
+      summary: Upload one or more activity files
+      description: |
+        Accepts 1–10 files as `multipart/form-data`. Each file is parsed,
+        persisted, and returned in the results array. Unsupported or unparseable
+        files produce a result with `success: false` rather than failing the
+        whole request.
+      security:
+        - csrfToken: []
+      requestBody:
+        required: true
+        content:
+          multipart/form-data:
+            schema:
+              type: object
+              properties:
+                files:
+                  type: array
+                  items:
+                    type: string
+                    format: binary
+                folderId:
+                  type: string
+                  format: uuid
+                  description: Optional folder to assign all uploaded events to
+      responses:
+        "200":
+          description: Upload results (one item per file)
+          content:
+            application/json:
+              schema:
+                type: object
+                required: [results]
+                properties:
+                  results:
+                    type: array
+                    items:
+                      $ref: "#/components/schemas/UploadResultItem"
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+
+  /api/events/activity-rows:
+    get:
+      tags: [events]
+      summary: Paginated activity table
+      description: Returns a paginated list of `{ event, activity }` pairs for the activity table view.
+      parameters:
+        - name: limit
+          in: query
+          schema:
+            type: integer
+            default: 20
+            maximum: 50
+        - name: offset
+          in: query
+          schema:
+            type: integer
+            default: 0
+        - name: startDate
+          in: query
+          schema:
+            type: integer
+        - name: endDate
+          in: query
+          schema:
+            type: integer
+        - name: activityTypes
+          in: query
+          schema:
+            type: array
+            items:
+              type: string
+          style: form
+          explode: true
+        - name: devices
+          in: query
+          schema:
+            type: array
+            items:
+              type: string
+          style: form
+          explode: true
+        - name: search
+          in: query
+          schema:
+            type: string
+          description: Partial match against event name, activity name, or activity type
+        - name: folderId
+          in: query
+          schema:
+            type: string
+      responses:
+        "200":
+          description: Paginated activity rows
+          content:
+            application/json:
+              schema:
+                type: object
+                required: [rows, total]
+                properties:
+                  rows:
+                    type: array
+                    items:
+                      $ref: "#/components/schemas/ActivityRow"
+                  total:
+                    type: integer
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+
+  /api/events/{id}:
+    get:
+      tags: [events]
+      summary: Get event detail
+      parameters:
+        - $ref: "#/components/parameters/eventId"
+      responses:
+        "200":
+          description: Event with activities and stats
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/EventDetail"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "404":
+          $ref: "#/components/responses/NotFound"
+
+    patch:
+      tags: [events]
+      summary: Update event folder assignment
+      security:
+        - csrfToken: []
+      parameters:
+        - $ref: "#/components/parameters/eventId"
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                folderId:
+                  type: string
+                  format: uuid
+                  nullable: true
+      responses:
+        "204":
+          description: Updated
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "403":
+          $ref: "#/components/responses/Forbidden"
+        "404":
+          $ref: "#/components/responses/NotFound"
+
+    delete:
+      tags: [events]
+      summary: Delete event
+      description: Deletes the event and any comparisons that reference it.
+      security:
+        - csrfToken: []
+      parameters:
+        - $ref: "#/components/parameters/eventId"
+      responses:
+        "204":
+          description: Deleted
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "403":
+          $ref: "#/components/responses/Forbidden"
+        "404":
+          $ref: "#/components/responses/NotFound"
+
+  /api/events/{id}/candidates:
+    get:
+      tags: [events]
+      summary: Get comparison candidates
+      description: |
+        Returns events that overlap in time with the given event and are in the
+        same folder (by default), suitable for building a new comparison.
+      parameters:
+        - $ref: "#/components/parameters/eventId"
+        - name: sameFolderOnly
+          in: query
+          schema:
+            type: boolean
+            default: true
+      responses:
+        "200":
+          description: Overlapping candidate events
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: "#/components/schemas/Event"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "404":
+          $ref: "#/components/responses/NotFound"
+
+  /api/events/{id}/activities/{activityId}:
+    patch:
+      tags: [events]
+      summary: Update activity type or device name
+      security:
+        - csrfToken: []
+      parameters:
+        - $ref: "#/components/parameters/eventId"
+        - $ref: "#/components/parameters/activityId"
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              description: At least one of type or deviceName must be provided
+              properties:
+                type:
+                  type: string
+                  example: Cycling
+                deviceName:
+                  type: string
+                  example: Wahoo ELEMNT Bolt
+      responses:
+        "200":
+          description: Updated activity
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Activity"
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "403":
+          $ref: "#/components/responses/Forbidden"
+        "404":
+          $ref: "#/components/responses/NotFound"
+
+  /api/events/{id}/activities/{activityId}/streams:
+    get:
+      tags: [events]
+      summary: Get streams for an activity
+      parameters:
+        - $ref: "#/components/parameters/eventId"
+        - $ref: "#/components/parameters/activityId"
+        - name: types
+          in: query
+          schema:
+            type: array
+            items:
+              type: string
+          style: form
+          explode: true
+          description: Filter to specific stream types. Omit to return all streams.
+      responses:
+        "200":
+          description: Streams with data points
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: "#/components/schemas/Stream"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "404":
+          $ref: "#/components/responses/NotFound"
+
+  # ── Comparisons ───────────────────────────────────────────────────────────
+
+  /api/comparisons:
+    get:
+      tags: [comparisons]
+      summary: List comparisons
+      parameters:
+        - name: folderId
+          in: query
+          schema:
+            type: string
+          description: |
+            Filter by folder UUID, `unfiled` for unassigned comparisons,
+            or omit for all comparisons. When a folder UUID is given, comparisons
+            that reference events in that folder are also included (`surfaced: true`).
+      responses:
+        "200":
+          description: List of comparisons
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: "#/components/schemas/Comparison"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+
+    post:
+      tags: [comparisons]
+      summary: Create a comparison
+      security:
+        - csrfToken: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required: [name, activityIds]
+              properties:
+                name:
+                  type: string
+                activityIds:
+                  type: array
+                  minItems: 2
+                  items:
+                    type: string
+                    format: uuid
+                settings:
+                  type: object
+                  nullable: true
+                folderId:
+                  type: string
+                  format: uuid
+                  nullable: true
+      responses:
+        "201":
+          description: Created comparison
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Comparison"
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "403":
+          $ref: "#/components/responses/Forbidden"
+        "404":
+          description: One or more activityIds not found or not owned
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+
+  /api/comparisons/by-events:
+    post:
+      tags: [comparisons]
+      summary: Get comparisons by event IDs
+      description: Returns lightweight comparison stubs for all comparisons that reference any of the given event IDs.
+      security:
+        - csrfToken: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required: [eventIds]
+              properties:
+                eventIds:
+                  type: array
+                  minItems: 1
+                  items:
+                    type: string
+                    format: uuid
+      responses:
+        "200":
+          description: Matching comparisons
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  type: object
+                  required: [id, name]
+                  properties:
+                    id:
+                      type: string
+                      format: uuid
+                    name:
+                      type: string
+                    createdAt:
+                      type: integer
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "403":
+          $ref: "#/components/responses/Forbidden"
+
+  /api/comparisons/{id}:
+    get:
+      tags: [comparisons]
+      summary: Get comparison by ID
+      parameters:
+        - $ref: "#/components/parameters/comparisonId"
+      responses:
+        "200":
+          description: Comparison detail
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Comparison"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "404":
+          $ref: "#/components/responses/NotFound"
+
+    delete:
+      tags: [comparisons]
+      summary: Delete comparison
+      security:
+        - csrfToken: []
+      parameters:
+        - $ref: "#/components/parameters/comparisonId"
+      responses:
+        "204":
+          description: Deleted
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "403":
+          $ref: "#/components/responses/Forbidden"
+        "404":
+          $ref: "#/components/responses/NotFound"
+
+  /api/comparisons/{id}/folder:
+    patch:
+      tags: [comparisons]
+      summary: Update comparison folder assignment
+      security:
+        - csrfToken: []
+      parameters:
+        - $ref: "#/components/parameters/comparisonId"
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required: [folderId]
+              properties:
+                folderId:
+                  type: string
+                  format: uuid
+                  nullable: true
+      responses:
+        "204":
+          description: Updated
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "403":
+          $ref: "#/components/responses/Forbidden"
+        "404":
+          $ref: "#/components/responses/NotFound"
+
+  /api/comparisons/{id}/settings:
+    patch:
+      tags: [comparisons]
+      summary: Update comparison settings
+      description: Persists arbitrary settings for a comparison (e.g. referenceActivityId for stream analysis).
+      security:
+        - csrfToken: []
+      parameters:
+        - $ref: "#/components/parameters/comparisonId"
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required: [settings]
+              properties:
+                settings:
+                  type: object
+                  nullable: true
+                  properties:
+                    referenceActivityId:
+                      type: string
+                      format: uuid
+                      nullable: true
+                  additionalProperties: true
+      responses:
+        "200":
+          description: Updated settings
+          content:
+            application/json:
+              schema:
+                type: object
+                required: [settings]
+                properties:
+                  settings:
+                    type: object
+                    nullable: true
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "403":
+          $ref: "#/components/responses/Forbidden"
+        "404":
+          $ref: "#/components/responses/NotFound"
+
+  # ── Folders ───────────────────────────────────────────────────────────────
+
+  /api/folders:
+    get:
+      tags: [folders]
+      summary: List folders
+      description: Returns all folders for the authenticated user, ordered by pinned desc then name asc, with event and comparison counts.
+      responses:
+        "200":
+          description: List of folders
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: "#/components/schemas/Folder"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+
+    post:
+      tags: [folders]
+      summary: Create folder
+      security:
+        - csrfToken: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required: [name, color]
+              properties:
+                name:
+                  type: string
+                  maxLength: 255
+                color:
+                  type: string
+                  description: Hex colour code (#rrggbb)
+                  example: "#3498db"
+                pinned:
+                  type: boolean
+                  default: false
+      responses:
+        "201":
+          description: Created folder
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Folder"
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "403":
+          $ref: "#/components/responses/Forbidden"
+
+  /api/folders/{id}:
+    get:
+      tags: [folders]
+      summary: Get folder by ID
+      parameters:
+        - $ref: "#/components/parameters/folderId"
+      responses:
+        "200":
+          description: Folder
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Folder"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "404":
+          $ref: "#/components/responses/NotFound"
+
+    patch:
+      tags: [folders]
+      summary: Update folder
+      description: Updates one or more of name, color, pinned. At least one field required.
+      security:
+        - csrfToken: []
+      parameters:
+        - $ref: "#/components/parameters/folderId"
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                name:
+                  type: string
+                color:
+                  type: string
+                pinned:
+                  type: boolean
+      responses:
+        "200":
+          description: Updated folder
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Folder"
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "403":
+          $ref: "#/components/responses/Forbidden"
+        "404":
+          $ref: "#/components/responses/NotFound"
+
+    delete:
+      tags: [folders]
+      summary: Delete folder
+      security:
+        - csrfToken: []
+      parameters:
+        - $ref: "#/components/parameters/folderId"
+        - name: contents
+          in: query
+          schema:
+            type: string
+            enum: [unfile, delete]
+            default: unfile
+          description: |
+            What to do with events and comparisons assigned to this folder.
+            `unfile` removes the folder assignment; `delete` deletes them.
+      responses:
+        "204":
+          description: Deleted
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "403":
+          $ref: "#/components/responses/Forbidden"
+        "404":
+          $ref: "#/components/responses/NotFound"
+
+  # ── Account ───────────────────────────────────────────────────────────────
+
+  /api/account/export:
+    get:
+      tags: [account]
+      summary: Export all user data
+      parameters:
+        - name: includeStreams
+          in: query
+          schema:
+            type: string
+            enum: ["true", "false"]
+          description: When `true`, stream data points are included in the export. Omit or set to `false` to export metadata only.
+      responses:
+        "200":
+          description: Full user data export
+          content:
+            application/json:
+              schema:
+                type: object
+                required:
+                  - user
+                  - identities
+                  - folders
+                  - events
+                  - eventStats
+                  - activities
+                  - activityStats
+                  - comparisons
+                  - comparisonEventActivities
+                  - streams
+                  - streamDataPoints
+                properties:
+                  user:
+                    type: object
+                  identities:
+                    type: array
+                  folders:
+                    type: array
+                  events:
+                    type: array
+                  eventStats:
+                    type: array
+                  activities:
+                    type: array
+                  activityStats:
+                    type: array
+                  comparisons:
+                    type: array
+                  comparisonEventActivities:
+                    type: array
+                  streams:
+                    type: array
+                  streamDataPoints:
+                    type: array
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "404":
+          $ref: "#/components/responses/NotFound"
+
+  /api/account:
+    delete:
+      tags: [account]
+      summary: Delete account
+      description: |
+        Permanently deletes the authenticated user and all associated data
+        (events, activities, comparisons, folders, streams). Cascade delete
+        is enforced at the database level. The current session is destroyed.
+      security:
+        - csrfToken: []
+      responses:
+        "204":
+          description: Account deleted
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "403":
+          $ref: "#/components/responses/Forbidden"
+        "404":
+          $ref: "#/components/responses/NotFound"
+
+  # ── Meta ──────────────────────────────────────────────────────────────────
+
+  /api/activity-types:
+    get:
+      tags: [meta]
+      summary: Get distinct activity types
+      description: Returns all distinct non-empty activity type strings from the authenticated user's activities, sorted alphabetically.
+      responses:
+        "200":
+          description: Activity types
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  type: string
+                example: [Cycling, Running, Swimming]
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+
+  /api/devices:
+    get:
+      tags: [meta]
+      summary: Get distinct device names
+      description: Returns all distinct non-empty device name strings from the authenticated user's activities, sorted alphabetically.
+      responses:
+        "200":
+          description: Device names
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  type: string
+                example: [Garmin Forerunner 245, Wahoo ELEMNT Bolt]
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+
+  # ── Health ────────────────────────────────────────────────────────────────
+
+  /health:
+    get:
+      tags: []
+      summary: Health check
+      description: Returns 200 when the API and database are reachable, 503 otherwise.
+      responses:
+        "200":
+          description: Healthy
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  ok:
+                    type: boolean
+        "503":
+          description: Unhealthy
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  ok:
+                    type: boolean
+                  error:
+                    type: string
+
+# Note: Session auth is cookie-based and not expressible as a standard
+# OpenAPI securityScheme. The csrfToken scheme below documents the
+# x-csrf-token header requirement for state-changing endpoints.

--- a/backend/src/repositories/activity-repository.js
+++ b/backend/src/repositories/activity-repository.js
@@ -1,5 +1,4 @@
-const { runQuery } = require('./query-helper');
-const { placeholders } = require('../utils/transforms');
+const { runQuery, placeholders } = require('./query-helper');
 
 const ACTIVITY_COLUMNS =
   'a.id, a.event_id, a.name, a.start_date, a.end_date, a.type, a.device_name, a.start_timezone, a.end_timezone, a.created_at';

--- a/backend/src/repositories/comparison-repository.js
+++ b/backend/src/repositories/comparison-repository.js
@@ -1,5 +1,4 @@
-const { runQuery } = require('./query-helper');
-const { placeholders } = require('../utils/transforms');
+const { runQuery, placeholders } = require('./query-helper');
 
 async function create(id, name, activityRows, settings, opts = {}) {
   if (!opts.userId) throw new Error('create comparison requires opts.userId');

--- a/backend/src/repositories/event-repository.js
+++ b/backend/src/repositories/event-repository.js
@@ -1,5 +1,4 @@
-const { runQuery } = require('./query-helper');
-const { placeholders } = require('../utils/transforms');
+const { runQuery, placeholders } = require('./query-helper');
 
 const EVENT_COLUMNS =
   'id, folder_id, start_date, name, end_date, description, is_merge, src_file_type, start_timezone, end_timezone';

--- a/backend/src/repositories/query-helper.js
+++ b/backend/src/repositories/query-helper.js
@@ -18,4 +18,25 @@ async function runQuery(sql, params, opts = {}) {
   return db.query(sql, params);
 }
 
-module.exports = { runQuery };
+/**
+ * Run a query and return the first row, or null. Transaction-aware like runQuery.
+ * @param {string} sql
+ * @param {Array} params
+ * @param {{ db?: object, conn?: object }} opts
+ * @returns {Promise<object|null>}
+ */
+async function runQueryOne(sql, params, opts = {}) {
+  const rows = await runQuery(sql, params, opts);
+  return Array.isArray(rows) ? (rows[0] ?? null) : null;
+}
+
+/**
+ * Generate SQL placeholder string for N params: ?,?,?
+ * @param {number} count
+ * @returns {string}
+ */
+function placeholders(count) {
+  return Array.from({ length: count }, () => '?').join(',');
+}
+
+module.exports = { runQuery, runQueryOne, placeholders };

--- a/backend/src/repositories/stream-repository.js
+++ b/backend/src/repositories/stream-repository.js
@@ -1,5 +1,4 @@
-const { runQuery } = require('./query-helper');
-const { placeholders } = require('../utils/transforms');
+const { runQuery, placeholders } = require('./query-helper');
 
 async function insertStream(streamId, activityId, eventId, type, opts = {}) {
   await runQuery(

--- a/backend/src/services/account-service.js
+++ b/backend/src/services/account-service.js
@@ -10,67 +10,64 @@ const defaultDb = require('../db');
 /**
  * Export all user data as a JSON-serialisable object.
  * Calls repositories directly (no other services) to avoid circular dependencies.
- * Uses batched IN(...) queries to avoid N+1 patterns.
+ * Uses batched IN(...) queries and Promise.all to minimise latency.
  *
  * @param {string} userId
  * @param {{ includeStreams?: boolean, db?: object }} opts
- * @returns {Promise<object>}
+ * @returns {Promise<object|null>}
  */
 async function exportUserData(userId, opts = {}) {
   const dbOpts = { db: opts.db ?? defaultDb, userId };
   const includeStreams = opts.includeStreams === true;
 
-  // User profile
+  // Level 1: user profile — needed to short-circuit if user not found
   const user = await userRepository.findById(userId, dbOpts);
   if (!user) return null;
 
-  // Identities (exclude profile_data for privacy)
-  const identityRows = await userRepository.findIdentitiesByUserId(userId, dbOpts);
+  // Level 2: all queries that depend only on userId (independent of each other)
+  const [identityRows, folderRows, eventRows, comparisonRows] = await Promise.all([
+    userRepository.findIdentitiesByUserId(userId, dbOpts),
+    folderRepository.listAll(userId, dbOpts),
+    eventRepository.findAllByUserId(userId, dbOpts),
+    comparisonRepository.findAllByUserId(userId, dbOpts),
+  ]);
 
-  // Folders
-  const folderRows = await folderRepository.listAll(userId, dbOpts);
-
-  // Events (include folder_id)
-  const eventRows = await eventRepository.findAllByUserId(userId, dbOpts);
   const eventIds = eventRows.map((e) => e.id);
-
-  // Event stats (batched)
-  const eventStatRows =
-    eventIds.length > 0 ? await eventRepository.getStatsByEventIds(eventIds, dbOpts) : [];
-
-  // Activities (batched)
-  const activityRows =
-    eventIds.length > 0 ? await activityRepository.findManyByEventIds(eventIds, dbOpts) : [];
-  const activityIds = activityRows.map((a) => a.id);
-
-  // Activity stats (batched)
-  const activityStatRows =
-    activityIds.length > 0
-      ? await activityRepository.getStatsByActivityIds(activityIds, dbOpts)
-      : [];
-
-  // Comparisons (include folder_id)
-  const comparisonRows = await comparisonRepository.findAllByUserId(userId, dbOpts);
   const comparisonIds = comparisonRows.map((c) => c.id);
 
-  // Comparison events/activities (batched)
-  const comparisonEventActivityRows =
+  // Level 3: queries that depend on eventIds or comparisonIds
+  const [eventStatRows, activityRows, comparisonEventActivityRows] = await Promise.all([
+    eventIds.length > 0
+      ? eventRepository.getStatsByEventIds(eventIds, dbOpts)
+      : Promise.resolve([]),
+    eventIds.length > 0
+      ? activityRepository.findManyByEventIds(eventIds, dbOpts)
+      : Promise.resolve([]),
     comparisonIds.length > 0
-      ? await comparisonRepository.findEventActivitiesByComparisonIds(comparisonIds, dbOpts)
-      : [];
+      ? comparisonRepository.findEventActivitiesByComparisonIds(comparisonIds, dbOpts)
+      : Promise.resolve([]),
+  ]);
 
-  // Streams metadata (batched) — always included; data points only if includeStreams
-  let streamRows = [];
+  const activityIds = activityRows.map((a) => a.id);
+
+  // Level 4: queries that depend on activityIds
+  const [activityStatRows, streamRows] = await Promise.all([
+    activityIds.length > 0
+      ? activityRepository.getStatsByActivityIds(activityIds, dbOpts)
+      : Promise.resolve([]),
+    activityIds.length > 0
+      ? streamRepository.findAllByActivityIds(activityIds, dbOpts)
+      : Promise.resolve([]),
+  ]);
+
+  // Level 5: stream data points (depend on streamIds, only if requested)
   let streamDataPointRows = [];
-  if (activityIds.length > 0) {
-    streamRows = await streamRepository.findAllByActivityIds(activityIds, dbOpts);
-    if (includeStreams && streamRows.length > 0) {
-      const streamIds = streamRows.map((s) => s.id);
-      streamDataPointRows = await streamRepository.findDataPointsByStreamIdsOrdered(
-        streamIds,
-        dbOpts
-      );
-    }
+  if (includeStreams && streamRows.length > 0) {
+    const streamIds = streamRows.map((s) => s.id);
+    streamDataPointRows = await streamRepository.findDataPointsByStreamIdsOrdered(
+      streamIds,
+      dbOpts
+    );
   }
 
   return {

--- a/backend/src/services/event-upload-service.js
+++ b/backend/src/services/event-upload-service.js
@@ -9,6 +9,54 @@ const activityRepository = require('../repositories/activity-repository');
 const streamRepository = require('../repositories/stream-repository');
 
 /**
+ * Build the event DB row from parsed event data. Pure function, no DB dependency.
+ * @param {object} eventJson - Parsed event JSON
+ * @param {string} name - Resolved event name
+ * @param {number} startDate - Resolved start date timestamp
+ * @param {string|null} folderId
+ * @param {string|null} extension - File extension (src_file_type)
+ * @returns {object} Event row ready for insertEvent (without id, user_id, timezone fields)
+ */
+function buildEventRecord(eventJson, name, startDate, folderId, extension) {
+  return {
+    start_date: startDate,
+    name,
+    end_date: toTimestamp(eventJson.endDate, null),
+    description: eventJson.description != null ? String(eventJson.description) : null,
+    is_merge: eventJson.isMerge === true || eventJson.isMerge === 1 ? 1 : 0,
+    src_file_type: extension || null,
+    folder_id: folderId,
+  };
+}
+
+/**
+ * Build the activity DB row from parsed activity data. Pure function, no DB dependency.
+ * @param {object} activityJson - Parsed activity JSON
+ * @param {string} aid - Activity UUID
+ * @param {string} eventId - Parent event UUID
+ * @returns {object} Activity row ready for insertActivity
+ */
+function buildActivityRecord(activityJson, aid, eventId) {
+  const { startTimezone, endTimezone } = extractActivityTimezones(activityJson);
+  return {
+    id: aid,
+    event_id: eventId,
+    name: activityJson.name != null ? String(activityJson.name) : null,
+    start_date: toTimestamp(activityJson.startDate, null),
+    end_date: toTimestamp(activityJson.endDate, null),
+    type: activityJson.type != null ? String(activityJson.type) : null,
+    device_name:
+      activityJson.creator &&
+      typeof activityJson.creator === 'object' &&
+      activityJson.creator.name != null
+        ? String(activityJson.creator.name).trim() || null
+        : null,
+    start_timezone: startTimezone,
+    end_timezone: endTimezone,
+  };
+}
+
+/**
  * Parses an uploaded file and persists event, activities, stats, and streams to the DB.
  */
 async function processUpload(fileBuffer, extension, originalFilename, opts = {}) {
@@ -27,28 +75,18 @@ async function processUpload(fileBuffer, extension, originalFilename, opts = {})
 
   const eventJson = event.toJSON();
   const eventStats = eventJson.stats && typeof eventJson.stats === 'object' ? eventJson.stats : {};
-  const eventEndDate = toTimestamp(eventJson.endDate, null);
-  const eventDescription = eventJson.description != null ? String(eventJson.description) : null;
-  const eventIsMerge = eventJson.isMerge === true || eventJson.isMerge === 1 ? 1 : 0;
-  const srcFileType = extension || null;
-
-  const activities = event.getActivities();
+  const folderId = opts.folderId != null && opts.folderId !== '' ? opts.folderId : null;
   const eventTimezone = FileParser.extractEventTimezone(event);
 
-  const folderId = opts.folderId != null && opts.folderId !== '' ? opts.folderId : null;
+  const activities = event.getActivities();
 
   await db.transaction(async (conn) => {
     const tOpts = { ...opts, db, conn };
+    const eventRow = buildEventRecord(eventJson, name, startDate, folderId, extension);
     await eventRepository.insertEvent(
       {
         id: eventId,
-        folder_id: folderId,
-        start_date: startDate,
-        name,
-        end_date: eventEndDate,
-        description: eventDescription,
-        is_merge: eventIsMerge,
-        src_file_type: srcFileType,
+        ...eventRow,
         start_timezone: eventTimezone,
         end_timezone: eventTimezone,
       },
@@ -62,32 +100,9 @@ async function processUpload(fileBuffer, extension, originalFilename, opts = {})
       const streams = activityJson.streams;
       const aStats =
         activityJson.stats && typeof activityJson.stats === 'object' ? activityJson.stats : {};
-      const aName = activityJson.name != null ? String(activityJson.name) : null;
-      const aStartDate = toTimestamp(activityJson.startDate, null);
-      const aEndDate = toTimestamp(activityJson.endDate, null);
-      const aType = activityJson.type != null ? String(activityJson.type) : null;
-      const deviceName =
-        activityJson.creator &&
-        typeof activityJson.creator === 'object' &&
-        activityJson.creator.name != null
-          ? String(activityJson.creator.name).trim()
-          : null;
-      const { startTimezone, endTimezone } = extractActivityTimezones(activityJson);
 
-      await activityRepository.insertActivity(
-        {
-          id: aid,
-          event_id: eventId,
-          name: aName,
-          start_date: aStartDate,
-          end_date: aEndDate,
-          type: aType,
-          device_name: deviceName || null,
-          start_timezone: startTimezone,
-          end_timezone: endTimezone,
-        },
-        tOpts
-      );
+      const activityRow = buildActivityRecord(activityJson, aid, eventId);
+      await activityRepository.insertActivity(activityRow, tOpts);
       await activityRepository.insertActivityStats(aid, aStats, tOpts);
 
       if (streams) {
@@ -133,4 +148,4 @@ async function processUpload(fileBuffer, extension, originalFilename, opts = {})
   };
 }
 
-module.exports = { processUpload };
+module.exports = { processUpload, buildEventRecord, buildActivityRecord };

--- a/backend/src/utils/transforms.js
+++ b/backend/src/utils/transforms.js
@@ -61,15 +61,10 @@ function mapActivityRow(row, statsForActivity = {}) {
   };
 }
 
-function placeholders(count) {
-  return Array.from({ length: count }, () => '?').join(',');
-}
-
 module.exports = {
   parseJSONField,
   toTimestamp,
   aggregateStats,
   mapEventRow,
   mapActivityRow,
-  placeholders,
 };

--- a/backend/test/helpers/fake-db.js
+++ b/backend/test/helpers/fake-db.js
@@ -1,6 +1,11 @@
-function makeFakeDb(queryFn) {
+function makeFakeDb(queryFn, queryOneFn) {
+  const _queryOneFn =
+    queryOneFn ??
+    ((sql, params) =>
+      Promise.resolve(queryFn(sql, params)).then((r) => (Array.isArray(r) ? (r[0] ?? null) : r)));
   return {
     query: queryFn,
+    queryOne: _queryOneFn,
     transaction: async (fn) => {
       const fakeConn = {
         execute: async (sql, params) => {

--- a/backend/test/unit/repositories/activity-repository.test.js
+++ b/backend/test/unit/repositories/activity-repository.test.js
@@ -1,0 +1,225 @@
+const { describe, it } = require('node:test');
+const { strictEqual, ok, deepStrictEqual } = require('node:assert/strict');
+const {
+  insertActivity,
+  insertActivityStats,
+  findByEventId,
+  findByIdAndEventId,
+  findManyByIds,
+  findManyByEventIds,
+  updateType,
+  updateDeviceName,
+  getStatsByActivityIds,
+  getStatsByActivityId,
+  getDistinctTypes,
+  getDistinctDeviceNames,
+} = require('../../../src/repositories/activity-repository');
+
+describe('activity-repository', () => {
+  describe('insertActivity', () => {
+    it('inserts activity row', async () => {
+      const queries = [];
+      const db = {
+        query: async (sql, params) => {
+          queries.push({ sql, params });
+          return { affectedRows: 1 };
+        },
+      };
+      await insertActivity(
+        {
+          id: 'a1',
+          event_id: 'e1',
+          name: 'Lap 1',
+          start_date: 1000,
+          end_date: 2000,
+          type: 'Running',
+          device_name: 'Garmin',
+          start_timezone: null,
+          end_timezone: null,
+        },
+        { db }
+      );
+      ok(queries[0].sql.includes('INSERT INTO activities'));
+      strictEqual(queries[0].params[0], 'a1');
+    });
+  });
+
+  describe('insertActivityStats', () => {
+    it('skips Device Names stat', async () => {
+      const queries = [];
+      const db = {
+        query: async (sql, params) => {
+          queries.push({ sql, params });
+          return { affectedRows: 1 };
+        },
+      };
+      await insertActivityStats('a1', { 'Device Names': ['Garmin'], Distance: 5000 }, { db });
+      strictEqual(queries.length, 1);
+      ok(!queries[0].params.join('').includes('Device Names'));
+    });
+
+    it('does not query when stats are empty', async () => {
+      let queryCount = 0;
+      const db = {
+        query: async () => {
+          queryCount++;
+          return {};
+        },
+      };
+      await insertActivityStats('a1', {}, { db });
+      strictEqual(queryCount, 0);
+    });
+  });
+
+  describe('findByEventId', () => {
+    it('throws when opts.userId is missing', async () => {
+      const db = { query: async () => [] };
+      await new Promise((resolve, reject) => {
+        findByEventId('e1', { db }).then(reject).catch(resolve);
+      });
+    });
+
+    it('returns activities for event', async () => {
+      const db = { query: async () => [{ id: 'a1', event_id: 'e1' }] };
+      const result = await findByEventId('e1', { db, userId: 'u1' });
+      strictEqual(result.length, 1);
+      strictEqual(result[0].id, 'a1');
+    });
+  });
+
+  describe('findByIdAndEventId', () => {
+    it('returns null when not found', async () => {
+      const db = { query: async () => [] };
+      const result = await findByIdAndEventId('a1', 'e1', { db, userId: 'u1' });
+      strictEqual(result, null);
+    });
+
+    it('returns activity when found', async () => {
+      const db = { query: async () => [{ id: 'a1', event_id: 'e1' }] };
+      const result = await findByIdAndEventId('a1', 'e1', { db, userId: 'u1' });
+      strictEqual(result.id, 'a1');
+    });
+  });
+
+  describe('findManyByIds', () => {
+    it('returns empty array for empty ids', async () => {
+      const result = await findManyByIds([], { userId: 'u1' });
+      deepStrictEqual(result, []);
+    });
+
+    it('includes IN clause for ids', async () => {
+      const queries = [];
+      const db = {
+        query: async (sql, params) => {
+          queries.push({ sql, params });
+          return [{ id: 'a1', event_id: 'e1' }];
+        },
+      };
+      const result = await findManyByIds(['a1'], { db, userId: 'u1' });
+      ok(queries[0].sql.includes('IN ('));
+      strictEqual(result.length, 1);
+    });
+  });
+
+  describe('findManyByEventIds', () => {
+    it('returns empty array for empty ids', async () => {
+      const result = await findManyByEventIds([], { userId: 'u1' });
+      deepStrictEqual(result, []);
+    });
+  });
+
+  describe('updateType', () => {
+    it('executes UPDATE with type', async () => {
+      const queries = [];
+      const db = {
+        query: async (sql, params) => {
+          queries.push({ sql, params });
+          return { affectedRows: 1 };
+        },
+      };
+      await updateType('a1', 'e1', 'Cycling', { db });
+      ok(queries[0].sql.includes('UPDATE activities'));
+      strictEqual(queries[0].params[0], 'Cycling');
+    });
+  });
+
+  describe('updateDeviceName', () => {
+    it('executes UPDATE with device name', async () => {
+      const queries = [];
+      const db = {
+        query: async (sql, params) => {
+          queries.push({ sql, params });
+          return { affectedRows: 1 };
+        },
+      };
+      await updateDeviceName('a1', 'e1', 'Garmin', { db });
+      ok(queries[0].sql.includes('UPDATE activities'));
+      strictEqual(queries[0].params[0], 'Garmin');
+    });
+  });
+
+  describe('getStatsByActivityIds', () => {
+    it('returns empty array for empty ids', async () => {
+      const result = await getStatsByActivityIds([], { userId: 'u1' });
+      deepStrictEqual(result, []);
+    });
+
+    it('queries activity_stats with IN clause', async () => {
+      const queries = [];
+      const db = {
+        query: async (sql, params) => {
+          queries.push({ sql, params });
+          return [{ activity_id: 'a1', stat_type: 'Distance', value: 5000 }];
+        },
+      };
+      const result = await getStatsByActivityIds(['a1'], { db, userId: 'u1' });
+      ok(queries[0].sql.includes('activity_stats'));
+      strictEqual(result.length, 1);
+    });
+  });
+
+  describe('getStatsByActivityId', () => {
+    it('throws when opts.userId is missing', async () => {
+      const db = { query: async () => [] };
+      await new Promise((resolve, reject) => {
+        getStatsByActivityId('a1', { db }).then(reject).catch(resolve);
+      });
+    });
+
+    it('returns stats rows for activity', async () => {
+      const db = { query: async () => [{ stat_type: 'HR', value: 140 }] };
+      const result = await getStatsByActivityId('a1', { db, userId: 'u1' });
+      strictEqual(result.length, 1);
+    });
+  });
+
+  describe('getDistinctTypes', () => {
+    it('throws when opts.userId is missing', async () => {
+      const db = { query: async () => [] };
+      await new Promise((resolve, reject) => {
+        getDistinctTypes({ db }).then(reject).catch(resolve);
+      });
+    });
+
+    it('returns distinct types', async () => {
+      const db = { query: async () => [{ type: 'Running' }, { type: 'Cycling' }] };
+      const result = await getDistinctTypes({ db, userId: 'u1' });
+      deepStrictEqual(result, ['Running', 'Cycling']);
+    });
+  });
+
+  describe('getDistinctDeviceNames', () => {
+    it('throws when opts.userId is missing', async () => {
+      const db = { query: async () => [] };
+      await new Promise((resolve, reject) => {
+        getDistinctDeviceNames({ db }).then(reject).catch(resolve);
+      });
+    });
+
+    it('returns distinct device names', async () => {
+      const db = { query: async () => [{ device_name: 'Garmin' }] };
+      const result = await getDistinctDeviceNames({ db, userId: 'u1' });
+      deepStrictEqual(result, ['Garmin']);
+    });
+  });
+});

--- a/backend/test/unit/repositories/comparison-repository.test.js
+++ b/backend/test/unit/repositories/comparison-repository.test.js
@@ -1,0 +1,209 @@
+const { describe, it } = require('node:test');
+const { strictEqual, ok, deepStrictEqual } = require('node:assert/strict');
+const {
+  create,
+  findAll,
+  findById,
+  findByEventIds,
+  existsById,
+  deleteById,
+  updateFolderId,
+  updateSettings,
+} = require('../../../src/repositories/comparison-repository');
+
+describe('comparison-repository', () => {
+  describe('create', () => {
+    it('throws when opts.userId is missing', async () => {
+      const db = { query: async () => ({ affectedRows: 1 }) };
+      await new Promise((resolve, reject) => {
+        create('c1', 'Test', [], null, { db }).then(reject).catch(resolve);
+      });
+    });
+
+    it('inserts comparison and activity link rows', async () => {
+      const queries = [];
+      const db = {
+        query: async (sql, params) => {
+          queries.push({ sql, params });
+          return { affectedRows: 1 };
+        },
+      };
+      await create(
+        'c1',
+        'Test Comparison',
+        [{ eventId: 'e1', activityId: 'a1' }],
+        null,
+        { db, userId: 'u1' }
+      );
+      const insertComp = queries.find((q) => q.sql.includes('INSERT INTO comparisons'));
+      ok(insertComp);
+      strictEqual(insertComp.params[0], 'c1');
+      strictEqual(insertComp.params[3], 'Test Comparison');
+
+      const insertLinks = queries.find((q) => q.sql.includes('comparison_event_activities'));
+      ok(insertLinks);
+    });
+
+    it('skips activity link insert when no activities provided', async () => {
+      const queries = [];
+      const db = {
+        query: async (sql, params) => {
+          queries.push({ sql, params });
+          return { affectedRows: 1 };
+        },
+      };
+      await create('c1', 'Empty', [], null, { db, userId: 'u1' });
+      const insertLinks = queries.find((q) => q.sql.includes('comparison_event_activities'));
+      strictEqual(insertLinks, undefined);
+    });
+  });
+
+  describe('findAll', () => {
+    it('throws when opts.userId is missing', async () => {
+      const db = { query: async () => [] };
+      await new Promise((resolve, reject) => {
+        findAll(10, { db }).then(reject).catch(resolve);
+      });
+    });
+
+    it('returns empty array when no comparisons', async () => {
+      const db = { query: async () => [] };
+      const result = await findAll(10, { db, userId: 'u1' });
+      deepStrictEqual(result, []);
+    });
+
+    it('joins activity links to comparisons', async () => {
+      let callCount = 0;
+      const db = {
+        query: async () => {
+          callCount++;
+          if (callCount === 1) return [{ id: 'c1', name: 'Test', folder_id: null }];
+          return [{ comparison_id: 'c1', event_id: 'e1', activity_id: 'a1' }];
+        },
+      };
+      const result = await findAll(10, { db, userId: 'u1' });
+      strictEqual(result.length, 1);
+      deepStrictEqual(result[0].event_ids, ['e1']);
+      deepStrictEqual(result[0].activity_ids, ['a1']);
+    });
+  });
+
+  describe('findById', () => {
+    it('throws when opts.userId is missing', async () => {
+      const db = { query: async () => [] };
+      await new Promise((resolve, reject) => {
+        findById('c1', { db }).then(reject).catch(resolve);
+      });
+    });
+
+    it('returns null when not found', async () => {
+      const db = { query: async () => [] };
+      const result = await findById('missing', { db, userId: 'u1' });
+      strictEqual(result, null);
+    });
+
+    it('returns comparison with event and activity ids', async () => {
+      let callCount = 0;
+      const db = {
+        query: async () => {
+          callCount++;
+          if (callCount === 1)
+            return [{ id: 'c1', name: 'Test', folder_id: null, settings: null }];
+          return [{ event_id: 'e1', activity_id: 'a1' }];
+        },
+      };
+      const result = await findById('c1', { db, userId: 'u1' });
+      ok(result);
+      deepStrictEqual(result.event_ids, ['e1']);
+      deepStrictEqual(result.activity_ids, ['a1']);
+    });
+  });
+
+  describe('existsById', () => {
+    it('returns true when found', async () => {
+      const db = { query: async () => [{ id: 'c1' }] };
+      const result = await existsById('c1', { db, userId: 'u1' });
+      strictEqual(result, true);
+    });
+
+    it('returns false when not found', async () => {
+      const db = { query: async () => [] };
+      const result = await existsById('missing', { db, userId: 'u1' });
+      strictEqual(result, false);
+    });
+  });
+
+  describe('deleteById', () => {
+    it('returns true when deleted', async () => {
+      const db = { query: async () => ({ affectedRows: 1 }) };
+      const result = await deleteById('c1', { db, userId: 'u1' });
+      strictEqual(result, true);
+    });
+
+    it('returns false when not found', async () => {
+      const db = { query: async () => ({ affectedRows: 0 }) };
+      const result = await deleteById('missing', { db, userId: 'u1' });
+      strictEqual(result, false);
+    });
+  });
+
+  describe('findByEventIds', () => {
+    it('returns empty array for empty event ids', async () => {
+      const result = await findByEventIds([], { userId: 'u1' });
+      deepStrictEqual(result, []);
+    });
+
+    it('queries with IN clause', async () => {
+      const queries = [];
+      const db = {
+        query: async (sql, params) => {
+          queries.push({ sql, params });
+          return [{ id: 'c1', name: 'Test' }];
+        },
+      };
+      const result = await findByEventIds(['e1'], { db, userId: 'u1' });
+      ok(queries[0].sql.includes('IN ('));
+      strictEqual(result.length, 1);
+    });
+  });
+
+  describe('updateFolderId', () => {
+    it('returns true when updated', async () => {
+      const db = { query: async () => ({ affectedRows: 1 }) };
+      const result = await updateFolderId('c1', 'f1', { db, userId: 'u1' });
+      strictEqual(result, true);
+    });
+
+    it('normalizes empty folderId to null', async () => {
+      const queries = [];
+      const db = {
+        query: async (sql, params) => {
+          queries.push(params);
+          return { affectedRows: 1 };
+        },
+      };
+      await updateFolderId('c1', '', { db, userId: 'u1' });
+      strictEqual(queries[0][0], null);
+    });
+  });
+
+  describe('updateSettings', () => {
+    it('returns true when updated', async () => {
+      const db = { query: async () => ({ affectedRows: 1 }) };
+      const result = await updateSettings('c1', { color: 'red' }, { db, userId: 'u1' });
+      strictEqual(result, true);
+    });
+
+    it('serializes settings as JSON', async () => {
+      const queries = [];
+      const db = {
+        query: async (sql, params) => {
+          queries.push(params);
+          return { affectedRows: 1 };
+        },
+      };
+      await updateSettings('c1', { color: 'blue' }, { db, userId: 'u1' });
+      strictEqual(queries[0][0], JSON.stringify({ color: 'blue' }));
+    });
+  });
+});

--- a/backend/test/unit/repositories/event-repository.test.js
+++ b/backend/test/unit/repositories/event-repository.test.js
@@ -1,0 +1,224 @@
+const { describe, it } = require('node:test');
+const { strictEqual, ok, deepStrictEqual } = require('node:assert/strict');
+const {
+  insertEvent,
+  findById,
+  findMany,
+  findManyByIds,
+  getStatsByEventIds,
+  getStatsByEventId,
+  updateFolderId,
+  deleteById,
+} = require('../../../src/repositories/event-repository');
+
+describe('event-repository', () => {
+  describe('insertEvent', () => {
+    it('throws when opts.userId is missing', async () => {
+      const db = { query: async () => ({ affectedRows: 1 }) };
+      await new Promise((resolve, reject) => {
+        insertEvent({ id: 'e1', start_date: 0, name: 'E' }, { db }).then(reject).catch(resolve);
+      });
+    });
+
+    it('inserts event row with userId', async () => {
+      const queries = [];
+      const db = {
+        query: async (sql, params) => {
+          queries.push({ sql, params });
+          return { affectedRows: 1 };
+        },
+      };
+      await insertEvent(
+        {
+          id: 'e1',
+          folder_id: null,
+          start_date: 1000,
+          name: 'Run',
+          end_date: null,
+          description: null,
+          is_merge: 0,
+          src_file_type: 'tcx',
+          start_timezone: null,
+          end_timezone: null,
+        },
+        { db, userId: 'u1' }
+      );
+      strictEqual(queries.length, 1);
+      ok(queries[0].sql.includes('INSERT INTO events'));
+      strictEqual(queries[0].params[0], 'e1');
+      strictEqual(queries[0].params[1], 'u1');
+    });
+  });
+
+  describe('findById', () => {
+    it('throws when opts.userId is missing', async () => {
+      const db = { query: async () => [] };
+      await new Promise((resolve, reject) => {
+        findById('e1', { db }).then(reject).catch(resolve);
+      });
+    });
+
+    it('returns event row when found', async () => {
+      const row = { id: 'e1', start_date: 1000, name: 'Run', folder_id: null };
+      const db = { query: async () => [row] };
+      const result = await findById('e1', { db, userId: 'u1' });
+      strictEqual(result.id, 'e1');
+    });
+
+    it('returns null when not found', async () => {
+      const db = { query: async () => [] };
+      const result = await findById('missing', { db, userId: 'u1' });
+      strictEqual(result, null);
+    });
+
+    it('filters by userId', async () => {
+      const queries = [];
+      const db = {
+        query: async (sql, params) => {
+          queries.push(params);
+          return [];
+        },
+      };
+      await findById('e1', { db, userId: 'u1' });
+      ok(queries[0].includes('u1'));
+    });
+  });
+
+  describe('findMany', () => {
+    it('throws when opts.userId is missing', async () => {
+      const db = { query: async () => [] };
+      await new Promise((resolve, reject) => {
+        findMany({}, { db }).then(reject).catch(resolve);
+      });
+    });
+
+    it('returns rows for user', async () => {
+      const db = { query: async () => [{ id: 'e1' }] };
+      const result = await findMany({}, { db, userId: 'u1' });
+      strictEqual(result.length, 1);
+    });
+
+    it('applies folderId=unfiled filter', async () => {
+      const queries = [];
+      const db = {
+        query: async (sql) => {
+          queries.push(sql);
+          return [];
+        },
+      };
+      await findMany({ folderId: 'unfiled' }, { db, userId: 'u1' });
+      ok(queries[0].includes('folder_id IS NULL'));
+    });
+
+    it('applies specific folderId filter', async () => {
+      const queries = [];
+      const db = {
+        query: async (sql, params) => {
+          queries.push({ sql, params });
+          return [];
+        },
+      };
+      await findMany({ folderId: 'f1' }, { db, userId: 'u1' });
+      ok(queries[0].sql.includes('folder_id = ?'));
+      ok(queries[0].params.includes('f1'));
+    });
+
+    it('caps limit at 200', async () => {
+      const queries = [];
+      const db = {
+        query: async (sql, params) => {
+          queries.push(params);
+          return [];
+        },
+      };
+      await findMany({ limit: 9999 }, { db, userId: 'u1' });
+      const limitParam = queries[0][queries[0].length - 1];
+      strictEqual(limitParam, 200);
+    });
+  });
+
+  describe('findManyByIds', () => {
+    it('returns empty array for empty ids', async () => {
+      const db = { query: async () => [] };
+      const result = await findManyByIds([], { db, userId: 'u1' });
+      deepStrictEqual(result, []);
+    });
+
+    it('includes IN clause for ids', async () => {
+      const queries = [];
+      const db = {
+        query: async (sql, params) => {
+          queries.push({ sql, params });
+          return [{ id: 'e1' }];
+        },
+      };
+      await findManyByIds(['e1', 'e2'], { db, userId: 'u1' });
+      ok(queries[0].sql.includes('IN ('));
+      ok(queries[0].params.includes('e1'));
+    });
+  });
+
+  describe('getStatsByEventIds', () => {
+    it('returns empty array for empty ids', async () => {
+      const db = { query: async () => [] };
+      const result = await getStatsByEventIds([], { db, userId: 'u1' });
+      deepStrictEqual(result, []);
+    });
+
+    it('queries event_stats with IN clause', async () => {
+      const queries = [];
+      const db = {
+        query: async (sql, params) => {
+          queries.push({ sql, params });
+          return [{ event_id: 'e1', stat_type: 'Distance', value: 5000 }];
+        },
+      };
+      const result = await getStatsByEventIds(['e1'], { db, userId: 'u1' });
+      ok(queries[0].sql.includes('event_stats'));
+      strictEqual(result.length, 1);
+    });
+  });
+
+  describe('getStatsByEventId', () => {
+    it('throws when opts.userId is missing', async () => {
+      const db = { query: async () => [] };
+      await new Promise((resolve, reject) => {
+        getStatsByEventId('e1', { db }).then(reject).catch(resolve);
+      });
+    });
+
+    it('returns stats rows for event', async () => {
+      const db = { query: async () => [{ stat_type: 'Distance', value: 5000 }] };
+      const result = await getStatsByEventId('e1', { db, userId: 'u1' });
+      strictEqual(result.length, 1);
+    });
+  });
+
+  describe('updateFolderId', () => {
+    it('returns true when row updated', async () => {
+      const db = { query: async () => ({ affectedRows: 1 }) };
+      const result = await updateFolderId('e1', 'f1', { db, userId: 'u1' });
+      strictEqual(result, true);
+    });
+
+    it('returns false when row not found', async () => {
+      const db = { query: async () => ({ affectedRows: 0 }) };
+      const result = await updateFolderId('missing', 'f1', { db, userId: 'u1' });
+      strictEqual(result, false);
+    });
+  });
+
+  describe('deleteById', () => {
+    it('returns true when deleted', async () => {
+      const db = { query: async () => ({ affectedRows: 1 }) };
+      const result = await deleteById('e1', { db, userId: 'u1' });
+      strictEqual(result, true);
+    });
+
+    it('returns false when not found', async () => {
+      const db = { query: async () => ({ affectedRows: 0 }) };
+      const result = await deleteById('missing', { db, userId: 'u1' });
+      strictEqual(result, false);
+    });
+  });
+});

--- a/backend/test/unit/repositories/folder-repository.test.js
+++ b/backend/test/unit/repositories/folder-repository.test.js
@@ -1,0 +1,249 @@
+const { describe, it } = require('node:test');
+const { strictEqual, ok, deepStrictEqual } = require('node:assert/strict');
+const {
+  create,
+  findById,
+  findByNameForUser,
+  countByUserId,
+  countPinnedByUserId,
+  listAll,
+  update,
+  deleteById,
+  getEventCountByFolderId,
+  getComparisonCountByFolderId,
+  findEventIdsByFolderId,
+  clearEventsFolderId,
+  clearComparisonsFolderId,
+  deleteComparisonsByFolderId,
+} = require('../../../src/repositories/folder-repository');
+
+describe('folder-repository', () => {
+  describe('create', () => {
+    it('throws when opts.userId is missing', async () => {
+      const db = { query: async () => ({ affectedRows: 1 }) };
+      await new Promise((resolve, reject) => {
+        create({ id: 'f1', name: 'F', color: '#fff', pinned: false }, { db })
+          .then(reject)
+          .catch(resolve);
+      });
+    });
+
+    it('inserts folder row with pinned=1 for pinned:true', async () => {
+      const queries = [];
+      const db = {
+        query: async (sql, params) => {
+          queries.push({ sql, params });
+          return { affectedRows: 1 };
+        },
+      };
+      await create({ id: 'f1', name: 'Training', color: '#ff0000', pinned: true }, { db, userId: 'u1' });
+      ok(queries[0].sql.includes('INSERT INTO folders'));
+      strictEqual(queries[0].params[2], 'Training');
+      strictEqual(queries[0].params[4], 1);
+    });
+
+    it('inserts folder row with pinned=0 for pinned:false', async () => {
+      const queries = [];
+      const db = {
+        query: async (sql, params) => {
+          queries.push({ sql, params });
+          return { affectedRows: 1 };
+        },
+      };
+      await create({ id: 'f1', name: 'Base', color: '#000', pinned: false }, { db, userId: 'u1' });
+      strictEqual(queries[0].params[4], 0);
+    });
+  });
+
+  describe('findById', () => {
+    it('throws when opts.userId is missing', async () => {
+      const db = { query: async () => [] };
+      await new Promise((resolve, reject) => {
+        findById('f1', { db }).then(reject).catch(resolve);
+      });
+    });
+
+    it('returns folder when found', async () => {
+      const db = { query: async () => [{ id: 'f1', name: 'Training' }] };
+      const result = await findById('f1', { db, userId: 'u1' });
+      strictEqual(result.id, 'f1');
+    });
+
+    it('returns null when not found', async () => {
+      const db = { query: async () => [] };
+      const result = await findById('missing', { db, userId: 'u1' });
+      strictEqual(result, null);
+    });
+  });
+
+  describe('findByNameForUser', () => {
+    it('returns folder when name matches', async () => {
+      const db = { query: async () => [{ id: 'f1' }] };
+      const result = await findByNameForUser('Training', 'u1', { db });
+      strictEqual(result.id, 'f1');
+    });
+
+    it('returns null when no match', async () => {
+      const db = { query: async () => [] };
+      const result = await findByNameForUser('Unknown', 'u1', { db });
+      strictEqual(result, null);
+    });
+  });
+
+  describe('countByUserId', () => {
+    it('returns count', async () => {
+      const db = { query: async () => [{ n: 5 }] };
+      const result = await countByUserId('u1', { db });
+      strictEqual(result, 5);
+    });
+
+    it('returns 0 on empty result', async () => {
+      const db = { query: async () => [] };
+      const result = await countByUserId('u1', { db });
+      strictEqual(result, 0);
+    });
+  });
+
+  describe('countPinnedByUserId', () => {
+    it('returns pinned count', async () => {
+      const db = { query: async () => [{ n: 2 }] };
+      const result = await countPinnedByUserId('u1', { db });
+      strictEqual(result, 2);
+    });
+  });
+
+  describe('listAll', () => {
+    it('returns all folders for user', async () => {
+      const db = { query: async () => [{ id: 'f1' }, { id: 'f2' }] };
+      const result = await listAll('u1', { db });
+      strictEqual(result.length, 2);
+    });
+
+    it('returns empty array when none', async () => {
+      const db = { query: async () => [] };
+      const result = await listAll('u1', { db });
+      deepStrictEqual(result, []);
+    });
+  });
+
+  describe('update', () => {
+    it('updates name when provided', async () => {
+      const queries = [];
+      const db = {
+        query: async (sql, params) => {
+          queries.push({ sql, params });
+          return { affectedRows: 1 };
+        },
+      };
+      await update('f1', { name: 'NewName' }, { db, userId: 'u1' });
+      ok(queries[0].sql.includes('name = ?'));
+      strictEqual(queries[0].params[0], 'NewName');
+    });
+
+    it('skips query when no fields provided', async () => {
+      let queryCount = 0;
+      const db = {
+        query: async () => {
+          queryCount++;
+          return {};
+        },
+      };
+      await update('f1', {}, { db, userId: 'u1' });
+      strictEqual(queryCount, 0);
+    });
+
+    it('updates color when provided', async () => {
+      const queries = [];
+      const db = {
+        query: async (sql, params) => {
+          queries.push({ sql, params });
+          return { affectedRows: 1 };
+        },
+      };
+      await update('f1', { color: '#00ff00' }, { db, userId: 'u1' });
+      ok(queries[0].sql.includes('color = ?'));
+      strictEqual(queries[0].params[0], '#00ff00');
+    });
+  });
+
+  describe('deleteById', () => {
+    it('returns true when deleted', async () => {
+      const db = { query: async () => ({ affectedRows: 1 }) };
+      const result = await deleteById('f1', { db, userId: 'u1' });
+      strictEqual(result, true);
+    });
+
+    it('returns false when not found', async () => {
+      const db = { query: async () => ({ affectedRows: 0 }) };
+      const result = await deleteById('missing', { db, userId: 'u1' });
+      strictEqual(result, false);
+    });
+  });
+
+  describe('getEventCountByFolderId', () => {
+    it('returns event count', async () => {
+      const db = { query: async () => [{ n: 3 }] };
+      const result = await getEventCountByFolderId('f1', { db, userId: 'u1' });
+      strictEqual(result, 3);
+    });
+  });
+
+  describe('getComparisonCountByFolderId', () => {
+    it('returns comparison count', async () => {
+      const db = { query: async () => [{ n: 1 }] };
+      const result = await getComparisonCountByFolderId('f1', { db, userId: 'u1' });
+      strictEqual(result, 1);
+    });
+  });
+
+  describe('findEventIdsByFolderId', () => {
+    it('returns event ids', async () => {
+      const db = { query: async () => [{ id: 'e1' }, { id: 'e2' }] };
+      const result = await findEventIdsByFolderId('f1', { db, userId: 'u1' });
+      deepStrictEqual(result, ['e1', 'e2']);
+    });
+  });
+
+  describe('clearEventsFolderId', () => {
+    it('executes UPDATE events SET folder_id = NULL', async () => {
+      const queries = [];
+      const db = {
+        query: async (sql) => {
+          queries.push(sql);
+          return { affectedRows: 1 };
+        },
+      };
+      await clearEventsFolderId('f1', { db, userId: 'u1' });
+      ok(queries[0].includes('folder_id = NULL'));
+    });
+  });
+
+  describe('clearComparisonsFolderId', () => {
+    it('executes UPDATE comparisons SET folder_id = NULL', async () => {
+      const queries = [];
+      const db = {
+        query: async (sql) => {
+          queries.push(sql);
+          return { affectedRows: 1 };
+        },
+      };
+      await clearComparisonsFolderId('f1', { db, userId: 'u1' });
+      ok(queries[0].includes('comparisons'));
+      ok(queries[0].includes('folder_id = NULL'));
+    });
+  });
+
+  describe('deleteComparisonsByFolderId', () => {
+    it('executes DELETE comparisons by folder', async () => {
+      const queries = [];
+      const db = {
+        query: async (sql) => {
+          queries.push(sql);
+          return { affectedRows: 1 };
+        },
+      };
+      await deleteComparisonsByFolderId('f1', { db, userId: 'u1' });
+      ok(queries[0].includes('DELETE FROM comparisons'));
+    });
+  });
+});

--- a/backend/test/unit/repositories/query-helper.test.js
+++ b/backend/test/unit/repositories/query-helper.test.js
@@ -1,0 +1,46 @@
+const { describe, it } = require('node:test');
+const { strictEqual } = require('node:assert/strict');
+const { placeholders, runQueryOne } = require('../../../src/repositories/query-helper');
+
+describe('query-helper', () => {
+  describe('placeholders', () => {
+    it('returns one placeholder for count 1', () => {
+      strictEqual(placeholders(1), '?');
+    });
+
+    it('returns comma-separated placeholders for count 3', () => {
+      strictEqual(placeholders(3), '?,?,?');
+    });
+
+    it('returns empty string for count 0', () => {
+      strictEqual(placeholders(0), '');
+    });
+  });
+
+  describe('runQueryOne', () => {
+    it('returns first row from db.query result', async () => {
+      const db = { query: async () => [{ id: 'r1' }, { id: 'r2' }] };
+      const result = await runQueryOne('SELECT 1', [], { db });
+      strictEqual(result.id, 'r1');
+    });
+
+    it('returns null when db.query returns empty array', async () => {
+      const db = { query: async () => [] };
+      const result = await runQueryOne('SELECT 1', [], { db });
+      strictEqual(result, null);
+    });
+
+    it('uses conn.execute when inside a transaction', async () => {
+      let executed = false;
+      const conn = {
+        execute: async () => {
+          executed = true;
+          return [[{ id: 'tx1' }]];
+        },
+      };
+      const result = await runQueryOne('SELECT 1', [], { conn });
+      strictEqual(result.id, 'tx1');
+      strictEqual(executed, true);
+    });
+  });
+});

--- a/backend/test/unit/repositories/stream-repository.test.js
+++ b/backend/test/unit/repositories/stream-repository.test.js
@@ -1,0 +1,152 @@
+const { describe, it } = require('node:test');
+const { strictEqual, ok, deepStrictEqual } = require('node:assert/strict');
+const { makeFakeDb } = require('../../helpers/fake-db');
+const {
+  insertStream,
+  insertStreamDataPointsBatch,
+  findAllByActivityIds,
+  findByActivityAndEvent,
+  findDataPointsByStreamIds,
+} = require('../../../src/repositories/stream-repository');
+
+describe('stream-repository', () => {
+  describe('insertStream', () => {
+    it('inserts with ON DUPLICATE KEY UPDATE', async () => {
+      const queries = [];
+      const db = makeFakeDb(async (sql, params) => {
+        queries.push({ sql, params });
+        return { affectedRows: 1 };
+      });
+      await insertStream('s1', 'a1', 'e1', 'Heart Rate', { db });
+      ok(queries[0].sql.includes('INSERT INTO streams'));
+      ok(queries[0].sql.includes('ON DUPLICATE KEY'));
+      strictEqual(queries[0].params[0], 's1');
+    });
+  });
+
+  describe('insertStreamDataPointsBatch', () => {
+    it('inserts data points in chunks of 1000', async () => {
+      const queries = [];
+      const db = makeFakeDb(async (sql, params) => {
+        queries.push({ sql, params });
+        return { affectedRows: params.length / 4 };
+      });
+      // 1500 data points — should produce 2 queries
+      const dataPoints = Array.from({ length: 1500 }, (_, i) => [
+        's1',
+        i * 1000,
+        JSON.stringify(i),
+        i,
+      ]);
+      await insertStreamDataPointsBatch('s1', dataPoints, { db });
+      strictEqual(queries.length, 2);
+      // First chunk: 1000 rows × 4 params = 4000 params
+      strictEqual(queries[0].params.length, 4000);
+      // Second chunk: 500 rows × 4 params = 2000 params
+      strictEqual(queries[1].params.length, 2000);
+    });
+
+    it('inserts all rows when fewer than 1000', async () => {
+      const queries = [];
+      const db = makeFakeDb(async (sql, params) => {
+        queries.push({ sql, params });
+        return { affectedRows: 1 };
+      });
+      const dataPoints = [
+        ['s1', 0, '1', 0],
+        ['s1', 1000, '2', 1],
+      ];
+      await insertStreamDataPointsBatch('s1', dataPoints, { db });
+      strictEqual(queries.length, 1);
+    });
+  });
+
+  describe('findAllByActivityIds', () => {
+    it('returns empty array for empty ids', async () => {
+      const result = await findAllByActivityIds([], { userId: 'u1' });
+      deepStrictEqual(result, []);
+    });
+
+    it('throws when opts.userId is missing', async () => {
+      const db = { query: async () => [] };
+      await new Promise((resolve, reject) => {
+        findAllByActivityIds(['a1'], { db }).then(reject).catch(resolve);
+      });
+    });
+
+    it('queries streams joined to events for ownership check', async () => {
+      const queries = [];
+      const db = {
+        query: async (sql, params) => {
+          queries.push({ sql, params });
+          return [{ id: 's1', activity_id: 'a1', event_id: 'e1', type: 'HR' }];
+        },
+      };
+      const result = await findAllByActivityIds(['a1'], { db, userId: 'u1' });
+      ok(queries[0].sql.includes('JOIN events'));
+      strictEqual(result.length, 1);
+    });
+  });
+
+  describe('findByActivityAndEvent', () => {
+    it('throws when opts.userId is missing', async () => {
+      const db = { query: async () => [] };
+      await new Promise((resolve, reject) => {
+        findByActivityAndEvent('a1', 'e1', [], { db }).then(reject).catch(resolve);
+      });
+    });
+
+    it('returns streams without type filter when types is null', async () => {
+      const queries = [];
+      const db = {
+        query: async (sql, params) => {
+          queries.push({ sql, params });
+          return [{ id: 's1', type: 'HR' }];
+        },
+      };
+      const result = await findByActivityAndEvent('a1', 'e1', null, { db, userId: 'u1' });
+      ok(!queries[0].sql.includes('s.type IN'));
+      strictEqual(result.length, 1);
+    });
+
+    it('applies type filter when types array is provided', async () => {
+      const queries = [];
+      const db = {
+        query: async (sql, params) => {
+          queries.push({ sql, params });
+          return [];
+        },
+      };
+      await findByActivityAndEvent('a1', 'e1', ['HR', 'Distance'], { db, userId: 'u1' });
+      ok(queries[0].sql.includes('s.type IN'));
+      ok(queries[0].params.includes('HR'));
+    });
+  });
+
+  describe('findDataPointsByStreamIds', () => {
+    it('returns empty array for empty ids', async () => {
+      const result = await findDataPointsByStreamIds([], { userId: 'u1' });
+      deepStrictEqual(result, []);
+    });
+
+    it('throws when opts.userId is missing', async () => {
+      const db = { query: async () => [] };
+      await new Promise((resolve, reject) => {
+        findDataPointsByStreamIds(['s1'], { db }).then(reject).catch(resolve);
+      });
+    });
+
+    it('orders results by stream_id, sequence_index, time_ms', async () => {
+      const queries = [];
+      const db = {
+        query: async (sql) => {
+          queries.push(sql);
+          return [];
+        },
+      };
+      await findDataPointsByStreamIds(['s1'], { db, userId: 'u1' });
+      ok(queries[0].includes('ORDER BY'));
+      ok(queries[0].includes('sequence_index'));
+    });
+  });
+});

--- a/backend/test/unit/routes/account-routes.test.js
+++ b/backend/test/unit/routes/account-routes.test.js
@@ -1,0 +1,116 @@
+const { describe, it } = require('node:test');
+const { strictEqual, deepStrictEqual } = require('node:assert/strict');
+const { mock } = require('node:test');
+const request = require('supertest');
+const express = require('express');
+const { errorHandler } = require('../../../src/middleware/error-handler');
+
+const ACCOUNT_ROUTER_PATH = require.resolve('../../../src/routes/account');
+const accountService = require('../../../src/services/account-service');
+
+function createApp(router) {
+  const app = express();
+  app.use(express.json());
+  app.use((req, _res, next) => {
+    req.userId = 'u1';
+    next();
+  });
+  app.use('/api/account', router);
+  app.use(errorHandler);
+  return app;
+}
+
+function getFreshRouter() {
+  delete require.cache[ACCOUNT_ROUTER_PATH];
+  return require('../../../src/routes/account');
+}
+
+describe('Account routes HTTP handler coverage', () => {
+  it('GET /export returns 200 with user data', async () => {
+    mock.method(accountService, 'exportUserData', async () => ({
+      user: { id: 'u1' },
+      events: [],
+    }));
+    try {
+      const router = getFreshRouter();
+      const app = createApp(router);
+      const res = await request(app).get('/api/account/export').expect(200);
+      strictEqual(res.body.user.id, 'u1');
+    } finally {
+      accountService.exportUserData.mock.restore();
+      delete require.cache[ACCOUNT_ROUTER_PATH];
+    }
+  });
+
+  it('GET /export returns 404 when user not found', async () => {
+    mock.method(accountService, 'exportUserData', async () => null);
+    try {
+      const router = getFreshRouter();
+      const app = createApp(router);
+      const res = await request(app).get('/api/account/export').expect(404);
+      deepStrictEqual(res.body, { error: 'User not found' });
+    } finally {
+      accountService.exportUserData.mock.restore();
+      delete require.cache[ACCOUNT_ROUTER_PATH];
+    }
+  });
+
+  it('GET /export with includeStreams=true passes flag to service', async () => {
+    let capturedOpts;
+    mock.method(accountService, 'exportUserData', async (userId, opts) => {
+      capturedOpts = opts;
+      return { user: { id: 'u1' }, events: [] };
+    });
+    try {
+      const router = getFreshRouter();
+      const app = createApp(router);
+      await request(app).get('/api/account/export?includeStreams=true').expect(200);
+      strictEqual(capturedOpts.includeStreams, true);
+    } finally {
+      accountService.exportUserData.mock.restore();
+      delete require.cache[ACCOUNT_ROUTER_PATH];
+    }
+  });
+
+  it('GET /export with includeStreams=false passes false flag to service', async () => {
+    let capturedOpts;
+    mock.method(accountService, 'exportUserData', async (userId, opts) => {
+      capturedOpts = opts;
+      return { user: { id: 'u1' }, events: [] };
+    });
+    try {
+      const router = getFreshRouter();
+      const app = createApp(router);
+      await request(app).get('/api/account/export?includeStreams=false').expect(200);
+      strictEqual(capturedOpts.includeStreams, false);
+    } finally {
+      accountService.exportUserData.mock.restore();
+      delete require.cache[ACCOUNT_ROUTER_PATH];
+    }
+  });
+
+  it('DELETE / returns 204 when account deleted', async () => {
+    mock.method(accountService, 'deleteAccount', async () => true);
+    try {
+      const router = getFreshRouter();
+      const app = createApp(router);
+      await request(app).delete('/api/account').expect(204);
+    } finally {
+      accountService.deleteAccount.mock.restore();
+      delete require.cache[ACCOUNT_ROUTER_PATH];
+    }
+  });
+
+  it('DELETE / returns 404 when user not found', async () => {
+    mock.method(accountService, 'deleteAccount', async () => false);
+    try {
+      const router = getFreshRouter();
+      const app = createApp(router);
+      const res = await request(app).delete('/api/account').expect(404);
+      deepStrictEqual(res.body, { error: 'User not found' });
+    } finally {
+      accountService.deleteAccount.mock.restore();
+      delete require.cache[ACCOUNT_ROUTER_PATH];
+    }
+  });
+});

--- a/backend/test/unit/routes/comparisons-routes.test.js
+++ b/backend/test/unit/routes/comparisons-routes.test.js
@@ -1,0 +1,164 @@
+const { describe, it } = require('node:test');
+const { strictEqual, deepStrictEqual, ok } = require('node:assert/strict');
+const { mock } = require('node:test');
+const request = require('supertest');
+const express = require('express');
+const { errorHandler } = require('../../../src/middleware/error-handler');
+
+const COMPARISONS_ROUTER_PATH = require.resolve('../../../src/routes/comparisons');
+const comparisonService = require('../../../src/services/comparison-service');
+
+const COMPARISON_ID = 'a1b2c3d4-e5f6-4789-a012-3456789abcde';
+const ACTIVITY_ID_1 = 'b2c3d4e5-f6a7-4890-b123-456789abcdef';
+const ACTIVITY_ID_2 = 'c3d4e5f6-a7b8-4901-c234-56789abcdef0';
+const FOLDER_UUID = 'd4e5f6a7-b8c9-4012-d345-6789abcdef01';
+
+function createApp(router) {
+  const app = express();
+  app.use(express.json());
+  app.use((req, _res, next) => {
+    req.userId = 'u1';
+    next();
+  });
+  app.use('/api/comparisons', router);
+  app.use(errorHandler);
+  return app;
+}
+
+function getFreshRouter() {
+  delete require.cache[COMPARISONS_ROUTER_PATH];
+  return require('../../../src/routes/comparisons');
+}
+
+describe('Comparisons routes HTTP handler coverage', () => {
+  it('GET / returns 200 with list of comparisons', async () => {
+    mock.method(comparisonService, 'getComparisons', async () => [{ id: 'c1', name: 'Test' }]);
+    try {
+      const router = getFreshRouter();
+      const app = createApp(router);
+      const res = await request(app).get('/api/comparisons').expect(200);
+      strictEqual(res.body.length, 1);
+      strictEqual(res.body[0].id, 'c1');
+    } finally {
+      comparisonService.getComparisons.mock.restore();
+      delete require.cache[COMPARISONS_ROUTER_PATH];
+    }
+  });
+
+  it('GET /:id returns 200 when found', async () => {
+    mock.method(comparisonService, 'getComparisonById', async () => ({
+      id: COMPARISON_ID,
+      name: 'Test',
+    }));
+    try {
+      const router = getFreshRouter();
+      const app = createApp(router);
+      const res = await request(app).get(`/api/comparisons/${COMPARISON_ID}`).expect(200);
+      strictEqual(res.body.id, COMPARISON_ID);
+    } finally {
+      comparisonService.getComparisonById.mock.restore();
+      delete require.cache[COMPARISONS_ROUTER_PATH];
+    }
+  });
+
+  it('GET /:id returns 404 when not found', async () => {
+    mock.method(comparisonService, 'getComparisonById', async () => null);
+    try {
+      const router = getFreshRouter();
+      const app = createApp(router);
+      const res = await request(app).get(`/api/comparisons/${COMPARISON_ID}`).expect(404);
+      deepStrictEqual(res.body, { error: 'Comparison not found' });
+    } finally {
+      comparisonService.getComparisonById.mock.restore();
+      delete require.cache[COMPARISONS_ROUTER_PATH];
+    }
+  });
+
+  it('POST / returns 400 when body is missing required fields', async () => {
+    const router = getFreshRouter();
+    const app = createApp(router);
+    const res = await request(app).post('/api/comparisons').send({}).expect(400);
+    ok(res.body.error);
+    delete require.cache[COMPARISONS_ROUTER_PATH];
+  });
+
+  it('POST / returns 201 when comparison created', async () => {
+    mock.method(comparisonService, 'createComparison', async () => ({
+      id: COMPARISON_ID,
+      name: 'New',
+      eventIds: [],
+      activityIds: [],
+      settings: null,
+      folderId: null,
+      createdAt: Date.now(),
+    }));
+    try {
+      const router = getFreshRouter();
+      const app = createApp(router);
+      const res = await request(app)
+        .post('/api/comparisons')
+        .send({ name: 'New', activityIds: [ACTIVITY_ID_1, ACTIVITY_ID_2] })
+        .expect(201);
+      strictEqual(res.body.id, COMPARISON_ID);
+    } finally {
+      comparisonService.createComparison.mock.restore();
+      delete require.cache[COMPARISONS_ROUTER_PATH];
+    }
+  });
+
+  it('DELETE /:id returns 204 when deleted', async () => {
+    mock.method(comparisonService, 'deleteComparisonById', async () => true);
+    try {
+      const router = getFreshRouter();
+      const app = createApp(router);
+      await request(app).delete(`/api/comparisons/${COMPARISON_ID}`).expect(204);
+    } finally {
+      comparisonService.deleteComparisonById.mock.restore();
+      delete require.cache[COMPARISONS_ROUTER_PATH];
+    }
+  });
+
+  it('DELETE /:id returns 404 when not found', async () => {
+    mock.method(comparisonService, 'deleteComparisonById', async () => false);
+    try {
+      const router = getFreshRouter();
+      const app = createApp(router);
+      const res = await request(app).delete(`/api/comparisons/${COMPARISON_ID}`).expect(404);
+      deepStrictEqual(res.body, { error: 'Comparison not found' });
+    } finally {
+      comparisonService.deleteComparisonById.mock.restore();
+      delete require.cache[COMPARISONS_ROUTER_PATH];
+    }
+  });
+
+  it('PATCH /:id/folder returns 204 when updated', async () => {
+    mock.method(comparisonService, 'updateComparisonFolder', async () => true);
+    try {
+      const router = getFreshRouter();
+      const app = createApp(router);
+      await request(app)
+        .patch(`/api/comparisons/${COMPARISON_ID}/folder`)
+        .send({ folderId: FOLDER_UUID })
+        .expect(204);
+    } finally {
+      comparisonService.updateComparisonFolder.mock.restore();
+      delete require.cache[COMPARISONS_ROUTER_PATH];
+    }
+  });
+
+  it('PATCH /:id/folder returns 404 when comparison not found', async () => {
+    mock.method(comparisonService, 'updateComparisonFolder', async () => false);
+    try {
+      const router = getFreshRouter();
+      const app = createApp(router);
+      const res = await request(app)
+        .patch(`/api/comparisons/${COMPARISON_ID}/folder`)
+        .send({ folderId: FOLDER_UUID })
+        .expect(404);
+      deepStrictEqual(res.body, { error: 'Comparison not found' });
+    } finally {
+      comparisonService.updateComparisonFolder.mock.restore();
+      delete require.cache[COMPARISONS_ROUTER_PATH];
+    }
+  });
+});

--- a/backend/test/unit/routes/folders-routes.test.js
+++ b/backend/test/unit/routes/folders-routes.test.js
@@ -1,0 +1,162 @@
+const { describe, it } = require('node:test');
+const { strictEqual, deepStrictEqual, ok } = require('node:assert/strict');
+const { mock } = require('node:test');
+const request = require('supertest');
+const express = require('express');
+const { errorHandler } = require('../../../src/middleware/error-handler');
+
+const FOLDERS_ROUTER_PATH = require.resolve('../../../src/routes/folders');
+const folderService = require('../../../src/services/folder-service');
+
+const FOLDER_ID = 'a1b2c3d4-e5f6-4789-a012-3456789abcde';
+
+function createApp(router) {
+  const app = express();
+  app.use(express.json());
+  app.use((req, _res, next) => {
+    req.userId = 'u1';
+    next();
+  });
+  app.use('/api/folders', router);
+  app.use(errorHandler);
+  return app;
+}
+
+function getFreshRouter() {
+  delete require.cache[FOLDERS_ROUTER_PATH];
+  return require('../../../src/routes/folders');
+}
+
+describe('Folders routes HTTP handler coverage', () => {
+  it('GET / returns 200 with folder list', async () => {
+    mock.method(folderService, 'listFolders', async () => [{ id: 'f1', name: 'Training' }]);
+    try {
+      const router = getFreshRouter();
+      const app = createApp(router);
+      const res = await request(app).get('/api/folders').expect(200);
+      strictEqual(res.body.length, 1);
+    } finally {
+      folderService.listFolders.mock.restore();
+      delete require.cache[FOLDERS_ROUTER_PATH];
+    }
+  });
+
+  it('POST / returns 400 when body is missing required fields', async () => {
+    const router = getFreshRouter();
+    const app = createApp(router);
+    const res = await request(app).post('/api/folders').send({}).expect(400);
+    ok(res.body.error);
+    delete require.cache[FOLDERS_ROUTER_PATH];
+  });
+
+  it('POST / returns 201 when folder created', async () => {
+    mock.method(folderService, 'createFolder', async () => ({
+      id: FOLDER_ID,
+      name: 'Training',
+      color: '#ff0000',
+      pinned: false,
+    }));
+    try {
+      const router = getFreshRouter();
+      const app = createApp(router);
+      const res = await request(app)
+        .post('/api/folders')
+        .send({ name: 'Training', color: '#ff0000' })
+        .expect(201);
+      strictEqual(res.body.id, FOLDER_ID);
+    } finally {
+      folderService.createFolder.mock.restore();
+      delete require.cache[FOLDERS_ROUTER_PATH];
+    }
+  });
+
+  it('GET /:id returns 200 when found', async () => {
+    mock.method(folderService, 'getFolderById', async () => ({
+      id: FOLDER_ID,
+      name: 'Training',
+    }));
+    try {
+      const router = getFreshRouter();
+      const app = createApp(router);
+      const res = await request(app).get(`/api/folders/${FOLDER_ID}`).expect(200);
+      strictEqual(res.body.id, FOLDER_ID);
+    } finally {
+      folderService.getFolderById.mock.restore();
+      delete require.cache[FOLDERS_ROUTER_PATH];
+    }
+  });
+
+  it('GET /:id returns 404 when not found', async () => {
+    mock.method(folderService, 'getFolderById', async () => null);
+    try {
+      const router = getFreshRouter();
+      const app = createApp(router);
+      const res = await request(app).get(`/api/folders/${FOLDER_ID}`).expect(404);
+      deepStrictEqual(res.body, { error: 'Folder not found' });
+    } finally {
+      folderService.getFolderById.mock.restore();
+      delete require.cache[FOLDERS_ROUTER_PATH];
+    }
+  });
+
+  it('PATCH /:id returns 200 when updated', async () => {
+    mock.method(folderService, 'updateFolder', async () => ({
+      id: FOLDER_ID,
+      name: 'Updated',
+      color: '#ff0000',
+    }));
+    try {
+      const router = getFreshRouter();
+      const app = createApp(router);
+      const res = await request(app)
+        .patch(`/api/folders/${FOLDER_ID}`)
+        .send({ name: 'Updated' })
+        .expect(200);
+      strictEqual(res.body.id, FOLDER_ID);
+    } finally {
+      folderService.updateFolder.mock.restore();
+      delete require.cache[FOLDERS_ROUTER_PATH];
+    }
+  });
+
+  it('PATCH /:id returns 404 when not found', async () => {
+    mock.method(folderService, 'updateFolder', async () => null);
+    try {
+      const router = getFreshRouter();
+      const app = createApp(router);
+      const res = await request(app)
+        .patch(`/api/folders/${FOLDER_ID}`)
+        .send({ name: 'Updated' })
+        .expect(404);
+      deepStrictEqual(res.body, { error: 'Folder not found' });
+    } finally {
+      folderService.updateFolder.mock.restore();
+      delete require.cache[FOLDERS_ROUTER_PATH];
+    }
+  });
+
+  it('DELETE /:id returns 204 when deleted', async () => {
+    mock.method(folderService, 'deleteFolder', async () => true);
+    try {
+      const router = getFreshRouter();
+      const app = createApp(router);
+      await request(app).delete(`/api/folders/${FOLDER_ID}`).expect(204);
+    } finally {
+      folderService.deleteFolder.mock.restore();
+      delete require.cache[FOLDERS_ROUTER_PATH];
+    }
+  });
+
+  it('DELETE /:id returns 404 when not found', async () => {
+    mock.method(folderService, 'deleteFolder', async () => false);
+    try {
+      const router = getFreshRouter();
+      const app = createApp(router);
+      const res = await request(app).delete(`/api/folders/${FOLDER_ID}`).expect(404);
+      deepStrictEqual(res.body, { error: 'Folder not found' });
+    } finally {
+      folderService.deleteFolder.mock.restore();
+      delete require.cache[FOLDERS_ROUTER_PATH];
+    }
+  });
+});

--- a/backend/test/unit/routes/meta-routes.test.js
+++ b/backend/test/unit/routes/meta-routes.test.js
@@ -1,0 +1,90 @@
+const { describe, it } = require('node:test');
+const { strictEqual } = require('node:assert/strict');
+const { mock } = require('node:test');
+const request = require('supertest');
+const express = require('express');
+const { errorHandler } = require('../../../src/middleware/error-handler');
+
+const META_ROUTER_PATH = require.resolve('../../../src/routes/meta');
+const metaService = require('../../../src/services/meta-service');
+
+function createApp(router) {
+  const app = express();
+  app.use(express.json());
+  app.use((req, _res, next) => {
+    req.userId = 'u1';
+    next();
+  });
+  app.use('/api', router);
+  app.use(errorHandler);
+  return app;
+}
+
+function getFreshRouter() {
+  delete require.cache[META_ROUTER_PATH];
+  return require('../../../src/routes/meta');
+}
+
+describe('Meta routes HTTP handler coverage', () => {
+  it('GET /activity-types returns 200 with types array', async () => {
+    mock.method(metaService, 'getActivityTypes', async () => ['Running', 'Cycling']);
+    try {
+      const router = getFreshRouter();
+      const app = createApp(router);
+      const res = await request(app).get('/api/activity-types').expect(200);
+      strictEqual(res.body.length, 2);
+      strictEqual(res.body[0], 'Running');
+    } finally {
+      metaService.getActivityTypes.mock.restore();
+      delete require.cache[META_ROUTER_PATH];
+    }
+  });
+
+  it('GET /devices returns 200 with devices array', async () => {
+    mock.method(metaService, 'getDevices', async () => ['Garmin', 'Polar']);
+    try {
+      const router = getFreshRouter();
+      const app = createApp(router);
+      const res = await request(app).get('/api/devices').expect(200);
+      strictEqual(res.body.length, 2);
+      strictEqual(res.body[0], 'Garmin');
+    } finally {
+      metaService.getDevices.mock.restore();
+      delete require.cache[META_ROUTER_PATH];
+    }
+  });
+
+  it('GET /activity-types passes userId to service', async () => {
+    let capturedOpts;
+    mock.method(metaService, 'getActivityTypes', async (opts) => {
+      capturedOpts = opts;
+      return [];
+    });
+    try {
+      const router = getFreshRouter();
+      const app = createApp(router);
+      await request(app).get('/api/activity-types').expect(200);
+      strictEqual(capturedOpts.userId, 'u1');
+    } finally {
+      metaService.getActivityTypes.mock.restore();
+      delete require.cache[META_ROUTER_PATH];
+    }
+  });
+
+  it('GET /devices passes userId to service', async () => {
+    let capturedOpts;
+    mock.method(metaService, 'getDevices', async (opts) => {
+      capturedOpts = opts;
+      return [];
+    });
+    try {
+      const router = getFreshRouter();
+      const app = createApp(router);
+      await request(app).get('/api/devices').expect(200);
+      strictEqual(capturedOpts.userId, 'u1');
+    } finally {
+      metaService.getDevices.mock.restore();
+      delete require.cache[META_ROUTER_PATH];
+    }
+  });
+});

--- a/backend/test/unit/transforms.test.js
+++ b/backend/test/unit/transforms.test.js
@@ -6,7 +6,6 @@ const {
   aggregateStats,
   mapEventRow,
   mapActivityRow,
-  placeholders,
 } = require('../../src/utils/transforms');
 
 describe('parseJSONField', () => {
@@ -229,16 +228,3 @@ describe('mapActivityRow', () => {
   });
 });
 
-describe('placeholders', () => {
-  it('returns one placeholder for count 1', () => {
-    strictEqual(placeholders(1), '?');
-  });
-
-  it('returns comma-separated placeholders for count 3', () => {
-    strictEqual(placeholders(3), '?,?,?');
-  });
-
-  it('returns empty string for count 0', () => {
-    strictEqual(placeholders(0), '');
-  });
-});

--- a/docs/PRD.md
+++ b/docs/PRD.md
@@ -244,6 +244,25 @@ Requirements:
 - broader import support
 - continued UX and accessibility improvements
 
+### Phase 5
+
+- integration and end-to-end testing
+
+Backend integration tests (real MariaDB container via `testcontainers-node`, separate CI job):
+
+- transaction correctness: multi-statement writes either fully commit or fully roll back
+- cascade deletes: deleting a user or event removes all child rows
+- schema constraint enforcement: duplicate identity provider rows are rejected at the DB level
+- OAuth session flow: pending signup → complete signup creates exactly one user and one identity
+
+Frontend + backend end-to-end tests (Playwright against the Docker Compose stack):
+
+- full upload → dashboard → event detail → comparison flow
+- folder create, assign, filter, and delete
+- account export and account delete
+
+CI integration: separate `integration` and `e2e` workflow jobs, not blocking the fast unit-test pipeline. Requires Docker-in-Docker or service containers in CI.
+
 ---
 
 ## 8. Constraints and assumptions


### PR DESCRIPTION
**Changes:**
 * Stage 1: add queryOne to makeFakeDb and runQueryOne + placeholders to query-helper
 * Stage 5: move placeholders from transforms.js to query-helper; update all repo imports; remove from transforms.test.js
 * Stage 4: decompose event-upload-service — extract buildEventRecord and buildActivityRecord as pure named functions
 * Stage 3: add unit tests for event, activity, comparison, folder, stream repositories and query-helper
 * Stage 6: add route unit tests for comparisons, folders, account, and meta routes
 * Stage 8: parallelise account-service.exportUserData with Promise.all at four dependency levels
 * Stage 9: add Phase 5 integration and e2e testing roadmap entry to PRD
 * Stage 10: add OpenAPI 3.1 spec (backend/docs/openapi.yaml) covering all endpoints; update AGENTS.md with API contract section