### PR TITLE
Frontend architectural review: type safety, bug fixes, and cleanups

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -66,7 +66,7 @@ The full machine-readable API specification is at [`backend/docs/openapi.yaml`](
 
 Key points:
 - All protected endpoints require a valid session cookie (`ofl.sid`).
-- All state-changing requests (POST, PATCH, DELETE) must include the `x-csrf-token` header. Obtain it from `GET /api/auth/me`.
+- All state-changing requests (POST, PATCH, DELETE) must include the `CSRF-Token` header. Obtain it from `GET /api/auth/me`.
 - Error responses are always `{ "error": "<message>" }`.
 - Missing or unowned resources return `404`, not `403`.
 - Response shapes for events and activities are produced by `mapEventRow` and `mapActivityRow` in `backend/src/utils/transforms.js`.

--- a/frontend/src/lib/api/__tests__/comparisons.test.ts
+++ b/frontend/src/lib/api/__tests__/comparisons.test.ts
@@ -65,6 +65,20 @@ describe('getComparisonCandidates', () => {
       /Failed to fetch comparison candidates/
     );
   });
+
+  it('throws when response is not an array', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue({
+        ok: true,
+        json: () => Promise.resolve({ id: 'evt-1' }),
+      })
+    );
+
+    await expect(getComparisonCandidates('evt-1')).rejects.toThrow(
+      /Invalid candidates response: expected array/
+    );
+  });
 });
 
 describe('getComparisons', () => {

--- a/frontend/src/lib/api/__tests__/events.test.ts
+++ b/frontend/src/lib/api/__tests__/events.test.ts
@@ -1,6 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import {
-  getEvents,
   getActivityRows,
   getEvent,
   getActivityTypes,
@@ -24,52 +23,6 @@ describe('fixtures', () => {
 
 beforeEach(() => {
   vi.restoreAllMocks();
-});
-
-describe('getEvents', () => {
-  it('includes limit=50 by default in URL', async () => {
-    const mockFetch = vi.fn().mockResolvedValue({
-      ok: true,
-      json: () => Promise.resolve([]),
-    });
-    vi.stubGlobal('fetch', mockFetch);
-
-    await getEvents();
-
-    expect(mockFetch).toHaveBeenCalledWith(expect.stringContaining('limit=50'), expect.any(Object));
-    expect(mockFetch).toHaveBeenCalledTimes(1);
-  });
-
-  it('includes startDate, endDate and limit when provided', async () => {
-    const mockFetch = vi.fn().mockResolvedValue({
-      ok: true,
-      json: () => Promise.resolve([]),
-    });
-    vi.stubGlobal('fetch', mockFetch);
-
-    await getEvents({
-      startDate: 1000,
-      endDate: 2000,
-      limit: 10,
-    });
-
-    const url = mockFetch.mock.calls[0][0];
-    expect(url).toContain('startDate=1000');
-    expect(url).toContain('endDate=2000');
-    expect(url).toContain('limit=10');
-  });
-
-  it('throws on non-ok response', async () => {
-    vi.stubGlobal(
-      'fetch',
-      vi.fn().mockResolvedValue({
-        ok: false,
-        statusText: 'Server Error',
-      })
-    );
-
-    await expect(getEvents()).rejects.toThrow(/Failed to fetch events/);
-  });
 });
 
 describe('getActivityRows', () => {
@@ -237,6 +190,20 @@ describe('getActivityTypes', () => {
 
     await expect(getActivityTypes()).rejects.toThrow(/Failed to fetch activity types/);
   });
+
+  it('throws when response is not an array', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue({
+        ok: true,
+        json: () => Promise.resolve({ types: [] }),
+      })
+    );
+
+    await expect(getActivityTypes()).rejects.toThrow(
+      /Invalid activity types response: expected array/
+    );
+  });
 });
 
 describe('getDevices', () => {
@@ -265,6 +232,18 @@ describe('getDevices', () => {
     );
 
     await expect(getDevices()).rejects.toThrow(/Failed to fetch devices/);
+  });
+
+  it('throws when response is not an array', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue({
+        ok: true,
+        json: () => Promise.resolve({ devices: [] }),
+      })
+    );
+
+    await expect(getDevices()).rejects.toThrow(/Invalid devices response: expected array/);
   });
 });
 

--- a/frontend/src/lib/api/__tests__/folders.test.ts
+++ b/frontend/src/lib/api/__tests__/folders.test.ts
@@ -1,0 +1,219 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { getFolders, getFolder, createFolder, updateFolder, deleteFolder } from '../folders';
+
+beforeEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe('getFolders', () => {
+  it('returns array of folders on success', async () => {
+    const folders = [{ id: 'f1', name: 'Runs', color: '#ef4444', pinned: false }];
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue({
+        ok: true,
+        json: () => Promise.resolve(folders),
+      })
+    );
+
+    const result = await getFolders();
+
+    expect(result).toEqual(folders);
+    expect(fetch).toHaveBeenCalledWith('/api/folders', expect.any(Object));
+  });
+
+  it('throws on non-ok response', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue({
+        ok: false,
+        statusText: 'Server Error',
+      })
+    );
+
+    await expect(getFolders()).rejects.toThrow(/Failed to fetch folders/);
+  });
+
+  it('throws when response is not an array', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue({
+        ok: true,
+        json: () => Promise.resolve({ id: 'f1' }),
+      })
+    );
+
+    await expect(getFolders()).rejects.toThrow(/Invalid folders response: expected array/);
+  });
+});
+
+describe('getFolder', () => {
+  it('returns folder on success', async () => {
+    const folder = { id: 'f1', name: 'Runs', color: '#ef4444', pinned: false };
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue({
+        ok: true,
+        json: () => Promise.resolve(folder),
+      })
+    );
+
+    const result = await getFolder('f1');
+
+    expect(result).toEqual(folder);
+    expect(fetch).toHaveBeenCalledWith('/api/folders/f1', expect.any(Object));
+  });
+
+  it('throws "Folder not found" on 404', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue({
+        ok: false,
+        status: 404,
+        statusText: 'Not Found',
+      })
+    );
+
+    await expect(getFolder('missing')).rejects.toThrow('Folder not found');
+  });
+
+  it('throws when response is missing id', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue({
+        ok: true,
+        json: () => Promise.resolve({ name: 'Runs' }),
+      })
+    );
+
+    await expect(getFolder('f1')).rejects.toThrow(/Invalid folder response: missing id/);
+  });
+});
+
+describe('createFolder', () => {
+  it('sends POST with body and returns folder', async () => {
+    const folder = { id: 'f1', name: 'Runs', color: '#ef4444', pinned: false };
+    const mockFetch = vi.fn().mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve(folder),
+    });
+    vi.stubGlobal('fetch', mockFetch);
+
+    const result = await createFolder({ name: 'Runs', color: '#ef4444' });
+
+    expect(result).toEqual(folder);
+    expect(mockFetch).toHaveBeenCalledWith(
+      '/api/folders',
+      expect.objectContaining({
+        method: 'POST',
+        body: JSON.stringify({ name: 'Runs', color: '#ef4444' }),
+      })
+    );
+  });
+
+  it('throws error from response body on failure', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue({
+        ok: false,
+        statusText: 'Bad Request',
+        json: () => Promise.resolve({ error: 'Name already taken' }),
+      })
+    );
+
+    await expect(createFolder({ name: 'Dup', color: '#000' })).rejects.toThrow(
+      'Name already taken'
+    );
+  });
+});
+
+describe('updateFolder', () => {
+  it('sends PATCH with body and returns updated folder', async () => {
+    const folder = { id: 'f1', name: 'Updated', color: '#3b82f6', pinned: true };
+    const mockFetch = vi.fn().mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve(folder),
+    });
+    vi.stubGlobal('fetch', mockFetch);
+
+    const result = await updateFolder('f1', { name: 'Updated', pinned: true });
+
+    expect(result).toEqual(folder);
+    expect(mockFetch).toHaveBeenCalledWith(
+      '/api/folders/f1',
+      expect.objectContaining({
+        method: 'PATCH',
+        body: JSON.stringify({ name: 'Updated', pinned: true }),
+      })
+    );
+  });
+
+  it('throws "Folder not found" on 404', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue({
+        ok: false,
+        status: 404,
+        statusText: 'Not Found',
+      })
+    );
+
+    await expect(updateFolder('missing', { name: 'x' })).rejects.toThrow('Folder not found');
+  });
+});
+
+describe('deleteFolder', () => {
+  it('calls apiFetch with method DELETE', async () => {
+    const mockFetch = vi.fn().mockResolvedValue({
+      ok: true,
+    });
+    vi.stubGlobal('fetch', mockFetch);
+
+    await deleteFolder('f1');
+
+    expect(mockFetch).toHaveBeenCalledWith(
+      '/api/folders/f1?contents=unfile',
+      expect.objectContaining({ method: 'DELETE' })
+    );
+  });
+
+  it('uses "delete" contents option when specified', async () => {
+    const mockFetch = vi.fn().mockResolvedValue({
+      ok: true,
+    });
+    vi.stubGlobal('fetch', mockFetch);
+
+    await deleteFolder('f1', 'delete');
+
+    expect(mockFetch).toHaveBeenCalledWith(
+      '/api/folders/f1?contents=delete',
+      expect.objectContaining({ method: 'DELETE' })
+    );
+  });
+
+  it('throws "Folder not found" on 404', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue({
+        ok: false,
+        status: 404,
+        statusText: 'Not Found',
+      })
+    );
+
+    await expect(deleteFolder('missing')).rejects.toThrow('Folder not found');
+  });
+
+  it('throws on other non-ok response', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue({
+        ok: false,
+        status: 500,
+        statusText: 'Server Error',
+      })
+    );
+
+    await expect(deleteFolder('f1')).rejects.toThrow(/Failed to delete folder/);
+  });
+});

--- a/frontend/src/lib/api/comparisons.ts
+++ b/frontend/src/lib/api/comparisons.ts
@@ -3,6 +3,16 @@ import type { EventSummary, Comparison, ComparisonSettings } from '../types/even
 const API_BASE = '/api';
 import { apiFetch } from './client';
 
+function assertComparisonArray(data: unknown): asserts data is Comparison[] {
+  if (!Array.isArray(data)) {
+    throw new Error('Invalid comparisons response: expected array');
+  }
+}
+
+function assertEventSummaryArray(data: unknown): asserts data is EventSummary[] {
+  if (!Array.isArray(data)) throw new Error('Invalid candidates response: expected array');
+}
+
 function assertComparison(data: unknown): asserts data is Comparison {
   const d = data as Record<string, unknown> | undefined;
   if (!d || typeof d.id !== 'string') {
@@ -39,7 +49,9 @@ export async function getComparisonCandidates(
     throw new Error(`Failed to fetch comparison candidates: ${response.statusText}`);
   }
 
-  return response.json();
+  const data = await response.json();
+  assertEventSummaryArray(data);
+  return data;
 }
 
 export interface GetComparisonsOptions {
@@ -59,7 +71,9 @@ export async function getComparisons(options?: GetComparisonsOptions): Promise<C
     throw new Error(`Failed to fetch comparisons: ${response.statusText}`);
   }
 
-  return response.json();
+  const data = await response.json();
+  assertComparisonArray(data);
+  return data;
 }
 
 export interface GetComparisonOptions {
@@ -103,7 +117,11 @@ export async function getComparisonsByEventIds(eventIds: string[]): Promise<Comp
     throw new Error(`Failed to fetch comparisons: ${response.statusText}`);
   }
 
-  return response.json();
+  const data = await response.json();
+  if (!Array.isArray(data)) {
+    throw new Error('Invalid comparisons response: expected array');
+  }
+  return data;
 }
 
 export interface CreateComparisonBody {

--- a/frontend/src/lib/api/events.ts
+++ b/frontend/src/lib/api/events.ts
@@ -1,5 +1,4 @@
 import type {
-  EventSummary,
   EventDetail,
   StreamData,
   BatchUploadResponse,
@@ -22,6 +21,25 @@ function assertEventDetail(data: unknown): asserts data is EventDetail {
   }
 }
 
+function assertActivityRowsResponse(
+  data: unknown
+): asserts data is { rows: ActivityRow[]; total: number } {
+  const d = data as Record<string, unknown> | undefined;
+  if (!Array.isArray(d?.rows)) {
+    throw new Error('Invalid activity rows response: missing rows array');
+  }
+  if (typeof d?.total !== 'number') {
+    throw new Error('Invalid activity rows response: missing total');
+  }
+}
+
+function assertActivity(data: unknown): asserts data is Activity {
+  const d = data as Record<string, unknown> | undefined;
+  if (!d || typeof d.id !== 'string') {
+    throw new Error('Invalid activity response: missing id');
+  }
+}
+
 function assertStreamDataArray(data: unknown): asserts data is StreamData[] {
   if (!Array.isArray(data)) {
     throw new Error('Invalid streams response: expected array');
@@ -35,32 +53,6 @@ function assertStreamDataArray(data: unknown): asserts data is StreamData[] {
       throw new Error(`Invalid streams response: item ${i} missing data array`);
     }
   }
-}
-
-export interface GetEventsParams {
-  startDate?: number;
-  endDate?: number;
-  limit?: number;
-}
-
-export async function getEvents(params?: GetEventsParams): Promise<EventSummary[]> {
-  const searchParams = new URLSearchParams();
-  if (params?.startDate != null) {
-    searchParams.set('startDate', String(params.startDate));
-  }
-  if (params?.endDate != null) {
-    searchParams.set('endDate', String(params.endDate));
-  }
-  searchParams.set('limit', String(params?.limit ?? 50));
-
-  const url = `${API_BASE}/events?${searchParams.toString()}`;
-  const response = await apiFetch(url);
-
-  if (!response.ok) {
-    throw new Error(`Failed to fetch events: ${response.statusText}`);
-  }
-
-  return response.json();
 }
 
 export interface GetActivityRowsParams {
@@ -103,7 +95,9 @@ export async function getActivityRows(
     throw new Error(`Failed to fetch activity rows: ${response.statusText}`);
   }
 
-  return response.json();
+  const data = await response.json();
+  assertActivityRowsResponse(data);
+  return data;
 }
 
 export interface GetEventOptions {
@@ -130,7 +124,9 @@ export async function getActivityTypes(): Promise<string[]> {
   if (!response.ok) {
     throw new Error(`Failed to fetch activity types: ${response.statusText}`);
   }
-  return response.json();
+  const data = await response.json();
+  if (!Array.isArray(data)) throw new Error('Invalid activity types response: expected array');
+  return data;
 }
 
 export async function getDevices(): Promise<string[]> {
@@ -138,7 +134,9 @@ export async function getDevices(): Promise<string[]> {
   if (!response.ok) {
     throw new Error(`Failed to fetch devices: ${response.statusText}`);
   }
-  return response.json();
+  const data = await response.json();
+  if (!Array.isArray(data)) throw new Error('Invalid devices response: expected array');
+  return data;
 }
 
 export async function updateActivity(
@@ -158,7 +156,9 @@ export async function updateActivity(
     const data = await response.json().catch(() => ({}));
     throw new Error(data.error || `Failed to update activity: ${response.statusText}`);
   }
-  return response.json();
+  const data = await response.json();
+  assertActivity(data);
+  return data;
 }
 
 export interface GetStreamsOptions {
@@ -289,10 +289,7 @@ export async function deleteEvent(id: string): Promise<boolean> {
   return true;
 }
 
-export async function updateEventFolder(
-  eventId: string,
-  folderId: string | null
-): Promise<EventDetail> {
+export async function updateEventFolder(eventId: string, folderId: string | null): Promise<void> {
   const response = await apiFetch(`${API_BASE}/events/${eventId}`, {
     method: 'PATCH',
     headers: { 'Content-Type': 'application/json' },
@@ -305,8 +302,4 @@ export async function updateEventFolder(
   if (!response.ok) {
     throw new Error(`Failed to update event folder: ${response.statusText}`);
   }
-
-  const data = await response.json();
-  assertEventDetail(data);
-  return data;
 }

--- a/frontend/src/lib/api/folders.ts
+++ b/frontend/src/lib/api/folders.ts
@@ -3,12 +3,23 @@ import { apiFetch } from './client';
 
 const API_BASE = '/api';
 
+function assertFolderArray(data: unknown): asserts data is Folder[] {
+  if (!Array.isArray(data)) throw new Error('Invalid folders response: expected array');
+}
+
+function assertFolder(data: unknown): asserts data is Folder {
+  const d = data as Record<string, unknown> | undefined;
+  if (!d || typeof d.id !== 'string') throw new Error('Invalid folder response: missing id');
+}
+
 export async function getFolders(): Promise<Folder[]> {
   const response = await apiFetch(`${API_BASE}/folders`);
   if (!response.ok) {
     throw new Error(`Failed to fetch folders: ${response.statusText}`);
   }
-  return response.json();
+  const data = await response.json();
+  assertFolderArray(data);
+  return data;
 }
 
 export async function getFolder(id: string): Promise<Folder> {
@@ -17,7 +28,9 @@ export async function getFolder(id: string): Promise<Folder> {
     if (response.status === 404) throw new Error('Folder not found');
     throw new Error(`Failed to fetch folder: ${response.statusText}`);
   }
-  return response.json();
+  const data = await response.json();
+  assertFolder(data);
+  return data;
 }
 
 export interface CreateFolderBody {
@@ -66,7 +79,9 @@ export async function deleteFolder(
   id: string,
   contents: 'unfile' | 'delete' = 'unfile'
 ): Promise<void> {
-  const response = await apiFetch(`${API_BASE}/folders/${id}?contents=${contents}`);
+  const response = await apiFetch(`${API_BASE}/folders/${id}?contents=${contents}`, {
+    method: 'DELETE',
+  });
   if (!response.ok) {
     if (response.status === 404) throw new Error('Folder not found');
     throw new Error(`Failed to delete folder: ${response.statusText}`);

--- a/frontend/src/lib/components/RouteMap.svelte
+++ b/frontend/src/lib/components/RouteMap.svelte
@@ -42,10 +42,16 @@
   }
   let { streams = [], routes }: Props = $props();
 
-  let selectedTheme = $state<MapTheme>('liberty');
+  let selectedTheme = $state<MapTheme>(
+    (localStorage.getItem('mapTheme') as MapTheme | null) ?? 'liberty'
+  );
   let showLabels = $state(true);
   let map = $state<MapLibreMap | undefined>(undefined);
   let arrowImageLoaded = $state<HTMLImageElement | null>(null);
+
+  $effect(() => {
+    localStorage.setItem('mapTheme', selectedTheme);
+  });
 
   const mapStyle = $derived(`https://tiles.openfreemap.org/styles/${selectedTheme}`);
 

--- a/frontend/src/lib/stores/__tests__/auth.test.ts
+++ b/frontend/src/lib/stores/__tests__/auth.test.ts
@@ -66,6 +66,21 @@ describe('auth store', () => {
     expect(state.csrfToken).toBe('token-pending');
   });
 
+  it('throws and clears state when /api/auth/me returns invalid response (missing csrfToken)', async () => {
+    vi.spyOn(globalThis as unknown as { fetch: typeof fetch }, 'fetch').mockResolvedValueOnce(
+      new Response(JSON.stringify({ id: 'u1', displayName: 'Alice' }), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      }) as unknown as Response
+    );
+
+    await checkAuth();
+
+    expect(state.user).toBeNull();
+    expect(state.csrfToken).toBeNull();
+    expect(state.authChecked).toBe(true);
+  });
+
   it('sets user and csrfToken to null when /api/auth/me returns non-ok', async () => {
     setCurrentUser({ id: 'u1', displayName: 'Alice', avatarUrl: null });
     state.csrfToken = 'old-token';

--- a/frontend/src/lib/stores/__tests__/folders.test.ts
+++ b/frontend/src/lib/stores/__tests__/folders.test.ts
@@ -1,0 +1,124 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { foldersState, loadFolders, getFolderFromHash, buildFolderHash } from '../folders.svelte';
+
+const mockGetFolders = vi.fn();
+
+vi.mock('../../api/folders', () => ({
+  getFolders: (...args: unknown[]) => mockGetFolders(...args),
+}));
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  foldersState.folders = [];
+  foldersState.loading = false;
+  foldersState.error = null;
+});
+
+describe('getFolderFromHash', () => {
+  it('returns "all" for an empty hash', () => {
+    expect(getFolderFromHash('')).toBe('all');
+  });
+
+  it('returns "all" for hash without folder param', () => {
+    expect(getFolderFromHash('#/')).toBe('all');
+    expect(getFolderFromHash('#/comparisons')).toBe('all');
+  });
+
+  it('returns "unfiled" for ?folder=unfiled', () => {
+    expect(getFolderFromHash('#/?folder=unfiled')).toBe('unfiled');
+  });
+
+  it('returns "all" for ?folder=all', () => {
+    expect(getFolderFromHash('#/?folder=all')).toBe('all');
+  });
+
+  it('returns the folder UUID for a valid UUID folder', () => {
+    const uuid = '550e8400-e29b-41d4-a716-446655440000';
+    expect(getFolderFromHash(`#/?folder=${uuid}`)).toBe(uuid);
+  });
+
+  it('returns "all" for a malformed hash with no folder value', () => {
+    expect(getFolderFromHash('#/?folder=')).toBe('all');
+    expect(getFolderFromHash('#/?folder=   ')).toBe('all');
+  });
+
+  it('handles encoded folder values', () => {
+    const uuid = '550e8400-e29b-41d4-a716-446655440000';
+    const encoded = encodeURIComponent(uuid);
+    expect(getFolderFromHash(`#/?folder=${encoded}`)).toBe(uuid);
+  });
+});
+
+describe('buildFolderHash', () => {
+  it('returns "#/" for "all"', () => {
+    expect(buildFolderHash('all')).toBe('#/');
+  });
+
+  it('returns encoded folder hash for a UUID', () => {
+    const uuid = '550e8400-e29b-41d4-a716-446655440000';
+    const hash = buildFolderHash(uuid);
+    expect(hash).toContain(uuid);
+    expect(hash).toMatch(/^#\//);
+  });
+
+  it('returns encoded folder hash for "unfiled"', () => {
+    const hash = buildFolderHash('unfiled');
+    expect(hash).toContain('unfiled');
+  });
+});
+
+describe('buildFolderHash / getFolderFromHash round-trip', () => {
+  it('round-trips "all"', () => {
+    expect(getFolderFromHash(buildFolderHash('all'))).toBe('all');
+  });
+
+  it('round-trips "unfiled"', () => {
+    expect(getFolderFromHash(buildFolderHash('unfiled'))).toBe('unfiled');
+  });
+
+  it('round-trips a UUID folder ID', () => {
+    const uuid = '550e8400-e29b-41d4-a716-446655440000';
+    expect(getFolderFromHash(buildFolderHash(uuid))).toBe(uuid);
+  });
+});
+
+describe('loadFolders', () => {
+  it('sets loading to true then false and populates folders', async () => {
+    const folders = [
+      { id: 'f1', name: 'Runs', color: '#ef4444', pinned: false },
+      { id: 'f2', name: 'Cycling', color: '#3b82f6', pinned: true },
+    ];
+    let capturedLoading: boolean | undefined;
+
+    mockGetFolders.mockImplementation(() => {
+      capturedLoading = foldersState.loading;
+      return Promise.resolve(folders);
+    });
+
+    await loadFolders();
+
+    expect(capturedLoading).toBe(true);
+    expect(foldersState.loading).toBe(false);
+    expect(foldersState.folders).toEqual(folders);
+    expect(foldersState.error).toBeNull();
+  });
+
+  it('sets loading to false and returns empty array on API error', async () => {
+    mockGetFolders.mockRejectedValue(new Error('Network error'));
+
+    const result = await loadFolders();
+
+    expect(result).toEqual([]);
+    expect(foldersState.loading).toBe(false);
+    expect(foldersState.error).toBe('Network error');
+    expect(foldersState.folders).toEqual([]);
+  });
+
+  it('sets a generic error message when thrown error is not an Error instance', async () => {
+    mockGetFolders.mockRejectedValue('some string error');
+
+    await loadFolders();
+
+    expect(foldersState.error).toBe('Failed to load folders');
+  });
+});

--- a/frontend/src/lib/stores/auth.svelte.ts
+++ b/frontend/src/lib/stores/auth.svelte.ts
@@ -1,4 +1,18 @@
 // Auth store for managing current user session (Svelte 5 runes)
+
+function assertAuthResponse(data: unknown): asserts data is {
+  csrfToken: string;
+  id?: string;
+  pendingSignup?: boolean;
+  displayName?: string | null;
+  avatarUrl?: string | null;
+  profile?: { displayName?: string | null; avatarUrl?: string | null };
+} {
+  if (!data || typeof data !== 'object') throw new Error('Invalid auth response');
+  const d = data as Record<string, unknown>;
+  if (typeof d.csrfToken !== 'string') throw new Error('Invalid auth response: missing csrfToken');
+}
+
 export interface AuthUser {
   id: string;
   displayName: string | null;
@@ -25,6 +39,7 @@ export async function checkAuth(): Promise<void> {
     const res = await fetch('/api/auth/me', { credentials: 'include' });
     if (res.ok) {
       const data = await res.json();
+      assertAuthResponse(data);
 
       if (data.pendingSignup) {
         state.pendingSignup = true;
@@ -36,7 +51,7 @@ export async function checkAuth(): Promise<void> {
         state.csrfToken = data.csrfToken ?? null;
       } else {
         state.user = {
-          id: data.id,
+          id: data.id ?? '',
           displayName: data.displayName ?? null,
           avatarUrl: data.avatarUrl ?? null,
         };

--- a/frontend/src/lib/types/event.ts
+++ b/frontend/src/lib/types/event.ts
@@ -111,7 +111,7 @@ export interface Comparison {
   name: string;
   eventIds: string[];
   /** Activity IDs for the comparison, parallel to eventIds (same order). */
-  activityIds?: string[];
+  activityIds: string[];
   settings?: ComparisonSettings;
   createdAt?: number;
   /** Home folder for this comparison; null/undefined = Unfiled. */

--- a/frontend/src/lib/utils/__tests__/comparison-chart-data.test.ts
+++ b/frontend/src/lib/utils/__tests__/comparison-chart-data.test.ts
@@ -1,5 +1,9 @@
 import { describe, it, expect } from 'vitest';
-import { buildComparisonChartData, type ComparisonChartEntry } from '../comparison-chart-data';
+import {
+  buildComparisonChartData,
+  calculateDelta,
+  type ComparisonChartEntry,
+} from '../comparison-chart-data';
 
 function entry(
   activityStartDate: number,
@@ -299,5 +303,53 @@ describe('buildComparisonChartData', () => {
       expect(result.xMin).toBe(0);
       expect(result.xMax).toBe(0);
     });
+  });
+});
+
+describe('calculateDelta', () => {
+  it('returns zero absolute and percent when values are the same', () => {
+    const result = calculateDelta(100, 100);
+    expect(result).toEqual({ absolute: 0, percent: 0 });
+  });
+
+  it('returns null when first value is not a number', () => {
+    expect(calculateDelta(null, 10)).toBeNull();
+    expect(calculateDelta('abc', 10)).toBeNull();
+    expect(calculateDelta(undefined, 10)).toBeNull();
+  });
+
+  it('returns null when second value is not a number', () => {
+    expect(calculateDelta(10, null)).toBeNull();
+    expect(calculateDelta(10, 'abc')).toBeNull();
+    expect(calculateDelta(10, undefined)).toBeNull();
+  });
+
+  it('returns null when both values are non-numeric', () => {
+    expect(calculateDelta(null, null)).toBeNull();
+    expect(calculateDelta('a', 'b')).toBeNull();
+  });
+
+  it('handles zero denominator: returns 100% when value2 is non-zero', () => {
+    const result = calculateDelta(0, 50);
+    expect(result).toEqual({ absolute: 50, percent: 100 });
+  });
+
+  it('handles zero denominator: returns 0% when both values are zero', () => {
+    const result = calculateDelta(0, 0);
+    expect(result).toEqual({ absolute: 0, percent: 0 });
+  });
+
+  it('calculates correct absolute and percent for normal case', () => {
+    const result = calculateDelta(200, 250);
+    expect(result).not.toBeNull();
+    expect(result!.absolute).toBe(50);
+    expect(result!.percent).toBeCloseTo(25);
+  });
+
+  it('calculates negative delta correctly', () => {
+    const result = calculateDelta(200, 150);
+    expect(result).not.toBeNull();
+    expect(result!.absolute).toBe(-50);
+    expect(result!.percent).toBeCloseTo(-25);
   });
 });

--- a/frontend/src/lib/utils/__tests__/comparison-loader.test.ts
+++ b/frontend/src/lib/utils/__tests__/comparison-loader.test.ts
@@ -1,0 +1,246 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { state, load, reset } from '../comparison-loader.svelte';
+import { eventDetailFixture, eventDetailEvt2Fixture } from '../../../test/fixtures/event-detail';
+import { streamsNoLocationFixture } from '../../../test/fixtures/streams';
+
+const mockGetEvent = vi.fn();
+const mockGetStreams = vi.fn();
+const mockGetComparison = vi.fn();
+
+vi.mock('../../api', () => ({
+  getEvent: (...args: unknown[]) => mockGetEvent(...args),
+  getStreams: (...args: unknown[]) => mockGetStreams(...args),
+  getComparison: (...args: unknown[]) => mockGetComparison(...args),
+}));
+
+beforeEach(() => {
+  reset();
+  vi.clearAllMocks();
+  mockGetStreams.mockResolvedValue([]);
+  mockGetEvent.mockImplementation((id: string) =>
+    Promise.resolve(id === 'evt-1' ? eventDetailFixture : eventDetailEvt2Fixture)
+  );
+});
+
+describe('load() with comparisonId === "new"', () => {
+  it('sets status to loaded and populates events with 2 valid event IDs', async () => {
+    load('new', ['evt-1', 'evt-2']);
+
+    await vi.waitFor(() => {
+      expect(state.status).toBe('loaded');
+    });
+
+    expect(state.events).toHaveLength(2);
+    expect(state.events[0].event.id).toBe('evt-1');
+    expect(state.events[1].event.id).toBe('evt-2');
+    expect(state.comparison).toBeNull();
+    expect(mockGetEvent).toHaveBeenCalledWith('evt-1', expect.any(Object));
+    expect(mockGetEvent).toHaveBeenCalledWith('evt-2', expect.any(Object));
+  });
+
+  it('sets status to error when fewer than 2 event IDs are provided', () => {
+    load('new', ['evt-1']);
+
+    expect(state.status).toBe('error');
+    expect(state.error).toMatch(/at least 2 events/i);
+  });
+
+  it('sets status to error when no event IDs are provided', () => {
+    load('new', []);
+
+    expect(state.status).toBe('error');
+    expect(state.error).toMatch(/at least 2 events/i);
+  });
+
+  it('clears selectedActivities and selectedStreamTypes on new load', async () => {
+    // Pre-populate some state
+    state.selectedStreamTypes = new Set(['Heart Rate']);
+
+    load('new', ['evt-1', 'evt-2']);
+
+    // selectedStreamTypes should be cleared on a new load
+    expect(state.selectedStreamTypes.size).toBe(0);
+
+    await vi.waitFor(() => {
+      expect(state.status).toBe('loaded');
+    });
+  });
+});
+
+describe('load() with a saved comparison ID', () => {
+  const comparisonId = 'cmp-1';
+
+  beforeEach(() => {
+    mockGetComparison.mockResolvedValue({
+      id: comparisonId,
+      name: 'Test Comparison',
+      eventIds: ['evt-1', 'evt-2'],
+      activityIds: ['act-1', 'act-2'],
+    });
+  });
+
+  it('loads comparison then events and streams', async () => {
+    load(comparisonId, []);
+
+    await vi.waitFor(() => {
+      expect(state.status).toBe('loaded');
+    });
+
+    expect(state.comparison).not.toBeNull();
+    expect(state.comparison?.id).toBe(comparisonId);
+    expect(state.events).toHaveLength(2);
+    expect(mockGetComparison).toHaveBeenCalledWith(comparisonId, expect.any(Object));
+    expect(mockGetEvent).toHaveBeenCalledWith('evt-1', expect.any(Object));
+    expect(mockGetEvent).toHaveBeenCalledWith('evt-2', expect.any(Object));
+  });
+
+  it('restores selectedActivities from comparison', async () => {
+    load(comparisonId, []);
+
+    await vi.waitFor(() => {
+      expect(state.status).toBe('loaded');
+    });
+
+    expect(state.selectedActivities['evt-1']).toBe('act-1');
+    expect(state.selectedActivities['evt-2']).toBe('act-2');
+  });
+
+  it('sets error when comparison fetch fails', async () => {
+    mockGetComparison.mockRejectedValue(new Error('Comparison not found'));
+
+    load(comparisonId, []);
+
+    await vi.waitFor(() => {
+      expect(state.status).toBe('error');
+    });
+
+    expect(state.error).toBe('Comparison not found');
+  });
+
+  it('resets hiddenStats and referenceActivityId when loading a comparison with no settings', async () => {
+    // Load comparison A with settings that set hiddenStats and referenceActivityId
+    mockGetComparison.mockResolvedValueOnce({
+      id: 'cmp-a',
+      name: 'Comparison A',
+      eventIds: ['evt-1', 'evt-2'],
+      activityIds: ['act-1', 'act-2'],
+      settings: {
+        hiddenStats: ['Distance', 'Pace'],
+        referenceActivityId: 'act-1',
+        xAxisMode: 'wall-clock',
+        selectedStreams: ['Heart Rate'],
+      },
+    });
+    load('cmp-a', []);
+    await vi.waitFor(() => expect(state.status).toBe('loaded'));
+
+    expect(state.hiddenStats.size).toBe(2);
+    expect(state.referenceActivityId).toBe('act-1');
+
+    // Load comparison B with no settings — prior state must be cleared
+    reset();
+    mockGetComparison.mockResolvedValueOnce({
+      id: 'cmp-b',
+      name: 'Comparison B',
+      eventIds: ['evt-1', 'evt-2'],
+      activityIds: ['act-1', 'act-2'],
+    });
+    load('cmp-b', []);
+    await vi.waitFor(() => expect(state.status).toBe('loaded'));
+
+    expect(state.hiddenStats.size).toBe(0);
+    expect(state.referenceActivityId).toBeNull();
+    expect(state.xAxisMode).toBe('elapsed');
+    expect(state.selectedStreamTypes.size).toBeLessThanOrEqual(1); // auto-selected at most 1
+  });
+});
+
+describe('stream auto-select: Heart Rate in event 2 only → Heart Rate selected', () => {
+  it('selects Heart Rate when it is present in any event streams', async () => {
+    const heartRateStreams = [{ type: 'Heart Rate', data: [{ time: 0, value: 120 }] }];
+    // evt-1 has no streams, evt-2 has Heart Rate
+    mockGetStreams.mockImplementation((_eventId: string, activityId: string) => {
+      if (activityId === 'act-2') return Promise.resolve(heartRateStreams);
+      return Promise.resolve([]);
+    });
+    mockGetEvent.mockImplementation((id: string) =>
+      Promise.resolve(id === 'evt-1' ? eventDetailFixture : eventDetailEvt2Fixture)
+    );
+
+    load('new', ['evt-1', 'evt-2']);
+
+    await vi.waitFor(() => {
+      expect(state.status).toBe('loaded');
+    });
+
+    // Heart Rate is in evt-2 streams, auto-select should pick it
+    expect(state.selectedStreamTypes.has('Heart Rate')).toBe(true);
+  });
+
+  it('selects first available stream type when no Heart Rate is present', async () => {
+    const speedStreams = [{ type: 'Speed', data: [{ time: 0, value: 5 }] }];
+    mockGetStreams.mockResolvedValue(speedStreams);
+
+    load('new', ['evt-1', 'evt-2']);
+
+    await vi.waitFor(() => {
+      expect(state.status).toBe('loaded');
+    });
+
+    // No Heart Rate, so first available stream type (Speed) should be selected
+    expect(state.selectedStreamTypes.size).toBeGreaterThan(0);
+  });
+
+  it('does not override existing selectedStreamTypes when already set', async () => {
+    mockGetComparison.mockResolvedValue({
+      id: 'cmp-1',
+      name: 'Saved',
+      eventIds: ['evt-1', 'evt-2'],
+      activityIds: ['act-1', 'act-2'],
+      settings: { selectedStreams: ['Speed'], xAxisMode: 'elapsed' },
+    });
+    mockGetStreams.mockResolvedValue(streamsNoLocationFixture);
+
+    load('cmp-1', []);
+
+    await vi.waitFor(() => {
+      expect(state.status).toBe('loaded');
+    });
+
+    // selectedStreamTypes set from saved comparison settings, not auto-selected
+    expect(state.selectedStreamTypes.has('Speed')).toBe(true);
+  });
+});
+
+describe('reset()', () => {
+  it('clears all state back to initial values', async () => {
+    // Load something first
+    load('new', ['evt-1', 'evt-2']);
+    await vi.waitFor(() => expect(state.status).toBe('loaded'));
+
+    reset();
+
+    expect(state.status).toBe('idle');
+    expect(state.comparison).toBeNull();
+    expect(state.events).toHaveLength(0);
+    expect(Object.keys(state.streamsByEventId)).toHaveLength(0);
+    expect(state.error).toBeNull();
+    expect(Object.keys(state.selectedActivities)).toHaveLength(0);
+    expect(state.selectedStreamTypes.size).toBe(0);
+    expect(state.xAxisMode).toBe('elapsed');
+    expect(state.hiddenStats.size).toBe(0);
+    expect(state.referenceActivityId).toBeNull();
+  });
+
+  it('allows a new load after reset', async () => {
+    load('new', ['evt-1', 'evt-2']);
+    await vi.waitFor(() => expect(state.status).toBe('loaded'));
+
+    reset();
+
+    load('new', ['evt-1', 'evt-2']);
+    await vi.waitFor(() => expect(state.status).toBe('loaded'));
+
+    expect(state.events).toHaveLength(2);
+  });
+});

--- a/frontend/src/lib/utils/comparison-chart-data.ts
+++ b/frontend/src/lib/utils/comparison-chart-data.ts
@@ -1,6 +1,23 @@
 import type uPlot from 'uplot';
 import type { StreamData } from '../types';
 
+/**
+ * Calculate the absolute and percent delta between two values.
+ * Returns null if either value is not a number.
+ */
+export function calculateDelta(
+  value1: unknown,
+  value2: unknown
+): { absolute: number; percent: number } | null {
+  const num1 = typeof value1 === 'number' ? value1 : null;
+  const num2 = typeof value2 === 'number' ? value2 : null;
+  if (num1 == null || num2 == null) return null;
+
+  const absolute = num2 - num1;
+  const percent = num1 !== 0 ? (absolute / num1) * 100 : num2 !== 0 ? 100 : 0;
+  return { absolute, percent };
+}
+
 export interface ComparisonChartEntry {
   eventName: string;
   color: string;

--- a/frontend/src/lib/utils/comparison-loader.svelte.ts
+++ b/frontend/src/lib/utils/comparison-loader.svelte.ts
@@ -163,11 +163,11 @@ async function loadEventsAndStreams(
           allStreamTypes.add(stream.type);
         }
       }
-      if (allStreamTypes.has('Heart Rate')) {
-        state.selectedStreamTypes = new Set(['Heart Rate']);
-      } else if (allStreamTypes.size > 0) {
-        state.selectedStreamTypes = new Set([Array.from(allStreamTypes)[0]]);
-      }
+    }
+    if (allStreamTypes.has('Heart Rate')) {
+      state.selectedStreamTypes = new Set(['Heart Rate']);
+    } else if (allStreamTypes.size > 0) {
+      state.selectedStreamTypes = new Set([Array.from(allStreamTypes)[0]]);
     }
   }
 }
@@ -236,6 +236,10 @@ export function load(comparisonId: string, eventIdsFromQuery: string[]): void {
     .then((comp) => {
       if (myGen !== loadGeneration) return;
       state.comparison = comp;
+      state.hiddenStats = new Set();
+      state.referenceActivityId = null;
+      state.xAxisMode = 'elapsed';
+      state.selectedStreamTypes = new Set();
       if (comp.settings) {
         state.xAxisMode = comp.settings.xAxisMode ?? 'elapsed';
         state.selectedStreamTypes = new Set(comp.settings.selectedStreams ?? []);
@@ -291,21 +295,31 @@ export async function loadStreams(): Promise<void> {
     return;
   }
 
+  if (abortController) abortController.abort();
+  abortController = new AbortController();
+  const signal = abortController.signal;
+
   const streamsToLoad: Record<string, StreamData[]> = {};
-  await Promise.all(
-    evs.map(async (eventDetail) => {
-      const eventId = eventDetail.event.id;
-      const activityId = state.selectedActivities[eventId];
-      if (!activityId) return;
-      try {
-        const loaded = await getStreams(eventId, activityId);
-        streamsToLoad[eventId] = loaded;
-      } catch (e) {
-        console.error(`Failed to load streams for event ${eventId}:`, e);
-        streamsToLoad[eventId] = [];
-      }
-    })
-  );
+  try {
+    await Promise.all(
+      evs.map(async (eventDetail) => {
+        const eventId = eventDetail.event.id;
+        const activityId = state.selectedActivities[eventId];
+        if (!activityId) return;
+        try {
+          const loaded = await getStreams(eventId, activityId, undefined, { signal });
+          streamsToLoad[eventId] = loaded;
+        } catch (e) {
+          if (isAbortError(e)) throw e;
+          console.error(`Failed to load streams for event ${eventId}:`, e);
+          streamsToLoad[eventId] = [];
+        }
+      })
+    );
+  } catch (e) {
+    if (isAbortError(e)) return;
+    throw e;
+  }
   state.streamsByEventId = streamsToLoad;
   loadedStreamsSignature = currentActivityIds;
 }

--- a/frontend/src/routes/__tests__/comparison-view.test.ts
+++ b/frontend/src/routes/__tests__/comparison-view.test.ts
@@ -41,6 +41,10 @@ vi.mock('../../lib/stores/folders.svelte', () => ({
   foldersState: {
     folders: [{ id: 'folder-1', name: 'Running', color: '#22c55e', pinned: false }],
   },
+  buildFolderHash: (folderId: string) => {
+    if (folderId === 'all') return '#/';
+    return `#/?folder=${encodeURIComponent(folderId)}`;
+  },
 }));
 
 describe('ComparisonView', () => {
@@ -129,7 +133,7 @@ describe('ComparisonView', () => {
       expect(screen.getByText('Event Comparison')).toBeInTheDocument();
     });
     await fireEvent.click(screen.getByRole('button', { name: '← Back to Workouts' }));
-    expect(mockPush).toHaveBeenCalledWith('/?folder=folder-abc');
+    expect(mockPush).toHaveBeenCalledWith('#/?folder=folder-abc');
   });
 
   it('Save Comparison opens dialog with auto-generated name', async () => {

--- a/frontend/src/routes/comparison-view.svelte
+++ b/frontend/src/routes/comparison-view.svelte
@@ -15,6 +15,7 @@
     getActivityDeviceName,
     hasLocationStreams,
   } from '../lib/utils';
+  import { calculateDelta } from '../lib/utils/comparison-chart-data';
   import {
     state as loaderState,
     load as loaderLoad,
@@ -37,16 +38,11 @@
   import ComparisonStatsTable from '../lib/components/comparison/ComparisonStatsTable.svelte';
   import StreamAnalysisSection from '../lib/components/comparison/StreamAnalysisSection.svelte';
   import RouteMap from '../lib/components/RouteMap.svelte';
-  import { foldersState } from '../lib/stores/folders.svelte';
+  import { foldersState, buildFolderHash } from '../lib/stores/folders.svelte';
 
   const comparisonId = $derived(params?.id ?? '');
 
-  // Sync router location to state so parsing effect re-runs when hash changes
-  let locationForEffect = $state('');
-  $effect(() => {
-    const unsub = location.subscribe((v) => (locationForEffect = v));
-    return unsub;
-  });
+  const currentLocation = $derived($location);
 
   // Parse query parameters from URL hash
   let eventIdsFromQueryState = $state<string[]>([]);
@@ -54,7 +50,7 @@
   let backFolderFromQueryState = $state<string | null>(null);
 
   $effect(() => {
-    const _loc = locationForEffect;
+    const _loc = currentLocation;
     if (query?.events) {
       const ids = query.events
         .split(',')
@@ -111,6 +107,7 @@
   let isSaving = $state(false);
   let isDeleting = $state(false);
   let saveError = $state<string | null>(null);
+  let deleteError = $state<string | null>(null);
 
   const eventIds = $derived.by(() => {
     if (comparisonId && comparisonId !== 'new' && loaderState.comparison) {
@@ -366,7 +363,7 @@
       await deleteComparison(savedComparison.id);
       push('/comparisons');
     } catch (e) {
-      loaderState.error = e instanceof Error ? e.message : 'Failed to delete comparison';
+      deleteError = e instanceof Error ? e.message : 'Failed to delete comparison';
       isDeleting = false;
     }
   }
@@ -422,20 +419,6 @@
     }
     return entries;
   }
-
-  // Calculate delta for stats (when exactly 2 events)
-  function calculateDelta(
-    value1: unknown,
-    value2: unknown
-  ): { absolute: number; percent: number } | null {
-    const num1 = typeof value1 === 'number' ? value1 : null;
-    const num2 = typeof value2 === 'number' ? value2 : null;
-    if (num1 == null || num2 == null) return null;
-
-    const absolute = num2 - num1;
-    const percent = num1 !== 0 ? (absolute / num1) * 100 : num2 !== 0 ? 100 : 0;
-    return { absolute, percent };
-  }
 </script>
 
 <section class="mx-auto w-[85%] max-w-screen-2xl py-6">
@@ -446,7 +429,7 @@
       if (savedComparison) {
         push('/comparisons');
       } else if (backFolderFromQueryState) {
-        push(`/?folder=${encodeURIComponent(backFolderFromQueryState)}`);
+        push(buildFolderHash(backFolderFromQueryState));
       } else {
         push('/');
       }
@@ -489,7 +472,7 @@
           {/if}
         {/if}
       </div>
-      <div class="flex gap-2">
+      <div class="flex flex-col items-end gap-2">
         {#if savedComparison}
           <button
             type="button"
@@ -499,6 +482,9 @@
           >
             {isDeleting ? 'Deleting...' : 'Delete'}
           </button>
+          {#if deleteError}
+            <p class="text-sm text-danger">{deleteError}</p>
+          {/if}
         {:else}
           <button
             type="button"

--- a/frontend/src/routes/workouts.svelte
+++ b/frontend/src/routes/workouts.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { onMount, untrack } from 'svelte';
+  import { untrack } from 'svelte';
   import { push } from 'svelte-spa-router';
   import {
     getActivityRows,
@@ -246,7 +246,7 @@
     eventToDelete = eventId;
   }
 
-  onMount(() => {
+  $effect(() => {
     getActivityTypes().then((r) => {
       activityTypesOptions = r;
     });


### PR DESCRIPTION
**Changes:**
 * Add runtime type guards to all API response paths (comparisons, events, folders, auth)
 * Fix deleteFolder: was sending GET instead of DELETE (bug fix)
 * Fix updateEventFolder return type to void (PATCH returns 204, not EventDetail)
 * Remove unused getEvents function and its tests
 * Extract calculateDelta as named export from comparison-chart-data
 * comparison-loader: fix stream type selection (was inside loop, now runs after all events loaded)
 * comparison-loader: reset UI state (hiddenStats, referenceActivityId, xAxisMode, selectedStreamTypes) on load()
 * comparison-loader: add AbortController to cancel in-flight stream requests on re-load
 * comparison-view: use buildFolderHash for back navigation (consistent with workouts route)
 * comparison-view: use $derived($location) instead of manual location subscription
 * comparison-view: separate deleteError state from loaderState.error
 * RouteMap: persist map theme selection to localStorage
 * workouts: replace onMount with $effect for activity types loading (Svelte 5 runes)
 * Make Comparison.activityIds required (was optional, always present from API)
 * Fix AGENTS.md CSRF header name (x-csrf-token → CSRF-Token)
 * Add tests for folders API, folders store, comparison-loader, and calculateDelta