### PR TITLE
Fix stale folder navigation after deletion

### DIFF
--- a/frontend/src/App.svelte
+++ b/frontend/src/App.svelte
@@ -373,7 +373,13 @@
         />
         <FolderDeleteModal
           folder={folderToDelete}
-          onDone={loadFolders}
+          onDone={() => {
+            const deletedId = folderToDelete?.id;
+            loadFolders();
+            if (deletedId && activeFolderValue === deletedId) {
+              window.location.hash = '#/';
+            }
+          }}
           onClosed={() => (folderToDelete = null)}
           onError={showFolderToast}
         />

--- a/frontend/src/routes/__tests__/App.test.ts
+++ b/frontend/src/routes/__tests__/App.test.ts
@@ -2,6 +2,16 @@ import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { render, screen, fireEvent, waitFor } from '@testing-library/svelte';
 import App from '../../App.svelte';
 import type { Writable } from 'svelte/store';
+import { foldersState, setFolderHash } from '../../lib/stores/folders.svelte';
+
+const mockDeleteFolder = vi.fn();
+const mockGetFolders = vi.fn();
+vi.mock('../../lib/api/folders', () => ({
+  getFolders: (...args: unknown[]) => mockGetFolders(...args),
+  deleteFolder: (...args: unknown[]) => mockDeleteFolder(...args),
+  updateFolder: vi.fn(),
+  createFolder: vi.fn(),
+}));
 
 interface AuthUser {
   id: string;
@@ -56,6 +66,8 @@ describe('App', () => {
 
   beforeEach(() => {
     mockCheckAuth.mockClear();
+    mockGetFolders.mockResolvedValue([]);
+    mockDeleteFolder.mockResolvedValue(undefined);
     mockAuthState.user = null;
     mockAuthState.authLoading = true;
     mockAuthState.authChecked = false;
@@ -71,6 +83,9 @@ describe('App', () => {
   });
 
   afterEach(() => {
+    setFolderHash('');
+    foldersState.folders = [];
+    foldersState.loading = false;
     vi.restoreAllMocks();
   });
 
@@ -293,6 +308,46 @@ describe('App', () => {
         const img = document.querySelector('img[alt="avatar"]');
         expect(img).toBeInTheDocument();
         expect(img).toHaveAttribute('src', 'https://example.com/avatar.png');
+      });
+    });
+  });
+
+  describe('folder deletion redirect', () => {
+    beforeEach(() => {
+      mockAuthState.authLoading = false;
+      mockAuthState.user = { id: 'u1', displayName: 'Test User', avatarUrl: null };
+    });
+
+    it('redirects to #/ when the active folder is deleted', async () => {
+      const folderId = 'folder-to-delete-id';
+      const testFolder = { id: folderId, name: 'My Folder', color: '#3b82f6', pinned: false };
+      mockGetFolders.mockResolvedValue([testFolder]);
+      setFolderHash(`#/?folder=${folderId}`);
+      window.location.hash = `#/?folder=${folderId}`;
+      render(App);
+
+      // Open folder context menu
+      await waitFor(() => {
+        expect(
+          screen.getByRole('button', { name: 'Folder options for My Folder' })
+        ).toBeInTheDocument();
+      });
+      await fireEvent.click(screen.getByRole('button', { name: 'Folder options for My Folder' }));
+
+      // Click Delete in context menu
+      await waitFor(() => {
+        expect(screen.getByRole('menuitem', { name: /Delete/ })).toBeInTheDocument();
+      });
+      await fireEvent.click(screen.getByRole('menuitem', { name: /Delete/ }));
+
+      // Confirm deletion in modal
+      await waitFor(() => {
+        expect(screen.getByRole('dialog')).toBeInTheDocument();
+      });
+      await fireEvent.click(screen.getByRole('button', { name: 'Move contents to Unfiled' }));
+
+      await waitFor(() => {
+        expect(window.location.hash).toBe('#/');
       });
     });
   });

--- a/frontend/src/routes/__tests__/workouts.test.ts
+++ b/frontend/src/routes/__tests__/workouts.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { render, screen, waitFor, fireEvent, within } from '@testing-library/svelte';
 import Workouts from '../workouts.svelte';
 import { activityRowsFixture } from '../../test/fixtures/activity-rows';
-import { setFolderHash } from '../../lib/stores/folders.svelte';
+import { setFolderHash, foldersState } from '../../lib/stores/folders.svelte';
 
 const mockGetActivityRows = vi.fn();
 const mockUploadFiles = vi.fn();
@@ -49,6 +49,8 @@ describe('Workouts', () => {
 
   afterEach(() => {
     setFolderHash('');
+    foldersState.folders = [];
+    foldersState.loading = false;
     vi.useRealTimers();
   });
 
@@ -521,5 +523,31 @@ describe('Workouts', () => {
       expect(screen.getByText('Candidates failed')).toBeInTheDocument();
     });
     consoleError.mockRestore();
+  });
+
+  it('shows folder not found banner when folder ID is unknown', async () => {
+    setFolderHash('#/?folder=non-existent-uuid');
+    foldersState.loading = false;
+    foldersState.folders = [];
+    render(Workouts);
+    await waitFor(() => {
+      expect(screen.getByRole('alert')).toHaveTextContent(
+        'Folder not found. It may have been deleted.'
+      );
+    });
+  });
+
+  it('does not show folder not found banner when folder ID is known', async () => {
+    const knownId = 'known-folder-uuid';
+    setFolderHash(`#/?folder=${knownId}`);
+    foldersState.loading = false;
+    foldersState.folders = [{ id: knownId, name: 'My Folder', color: '#3b82f6', pinned: false }];
+    render(Workouts);
+    await waitFor(() => {
+      expect(screen.getByText('Morning Run')).toBeInTheDocument();
+    });
+    expect(
+      screen.queryByText('Folder not found. It may have been deleted.')
+    ).not.toBeInTheDocument();
   });
 });

--- a/frontend/src/routes/workouts.svelte
+++ b/frontend/src/routes/workouts.svelte
@@ -117,6 +117,13 @@
           })()
   );
 
+  const isFolderNotFound = $derived(
+    !foldersState.loading &&
+      activeFolderId !== 'all' &&
+      activeFolderId !== 'unfiled' &&
+      foldersState.folders.find((f) => f.id === activeFolderId) === undefined
+  );
+
   function showToast(message: string) {
     toastMessage = message;
     if (toastTimeout) clearTimeout(toastTimeout);
@@ -349,6 +356,15 @@
     bind:isDraggingOver
     {activeFolderDisplay}
   >
+    {#if isFolderNotFound}
+      <div
+        class="mb-4 rounded border border-danger/50 bg-danger/10 px-4 py-3 text-sm text-danger"
+        role="alert"
+      >
+        Folder not found. It may have been deleted.
+      </div>
+    {/if}
+
     <!-- Loading Spinner (only for loading events, not uploads) -->
     {#if isLoading}
       <div class="mb-4">


### PR DESCRIPTION
**Changes:**
 * Redirect to #/ in App.svelte when the deleted folder is the currently active one
 * Show "Folder not found" error banner in workouts.svelte when the active folder ID is not in the loaded folder list
 * Add App test: deleting the active folder via the delete modal redirects window.location.hash to #/
 * Add workouts tests: unknown folder ID shows banner; known folder ID does not