### PR TITLE
Fix backup container permission errors

### DIFF
--- a/backup/Dockerfile
+++ b/backup/Dockerfile
@@ -1,19 +1,25 @@
 FROM alpine:3.21
-RUN apk add --no-cache restic mysql-client bash
+ARG SUPERCRONIC_VERSION=0.2.33
+
+RUN apk add --no-cache restic mysql-client bash wget \
+    && ARCH=$(uname -m | sed 's/x86_64/amd64/;s/aarch64/arm64/') \
+    && wget -qO /usr/local/bin/supercronic \
+         "https://github.com/aptible/supercronic/releases/download/v${SUPERCRONIC_VERSION}/supercronic-linux-${ARCH}" \
+    && chmod +x /usr/local/bin/supercronic
+
+ENV RESTIC_CACHE_DIR=/var/cache/restic
 
 RUN adduser -D -H -s /sbin/nologin backup
 
 COPY entrypoint.sh /entrypoint.sh
 COPY backup.sh /backup.sh
 COPY restore.sh /restore.sh
+COPY crontab /crontab
+
 RUN chmod +x /entrypoint.sh /backup.sh /restore.sh \
-    && mkdir -p /var/spool/cron/crontabs \
-    && echo "0 * * * * /backup.sh >> /var/log/backup.log 2>&1" > /var/spool/cron/crontabs/backup \
-    && chmod 600 /var/spool/cron/crontabs/backup \
-    && chown backup:backup /var/spool/cron/crontabs/backup \
-    && mkdir -p /restores \
+    && mkdir -p /restores /var/cache/restic \
     && touch /var/log/backup.log \
-    && chown backup:backup /restores /var/log/backup.log
+    && chown backup:backup /restores /var/cache/restic /var/log/backup.log
 
 USER backup
 ENTRYPOINT ["/entrypoint.sh"]

--- a/backup/crontab
+++ b/backup/crontab
@@ -1,0 +1,1 @@
+0 * * * * /backup.sh >> /var/log/backup.log 2>&1

--- a/backup/entrypoint.sh
+++ b/backup/entrypoint.sh
@@ -5,4 +5,4 @@ restic snapshots &>/dev/null || restic init
 
 /backup.sh
 
-exec crond -f -d 8
+exec supercronic /crontab


### PR DESCRIPTION
**Changes:**
 * Replace BusyBox crond with supercronic for reliable non-root cron
 * Add /var/cache/restic owned by backup user, set RESTIC_CACHE_DIR
 * Add backup/crontab as plain crontab file for supercronic
 * Update entrypoint.sh to exec supercronic instead of crond