### PR TITLE
Fix backup container supercronic crashloop

### DIFF
--- a/backup/Dockerfile
+++ b/backup/Dockerfile
@@ -18,8 +18,7 @@ COPY crontab /crontab
 
 RUN chmod +x /entrypoint.sh /backup.sh /restore.sh \
     && mkdir -p /restores /var/cache/restic \
-    && touch /var/log/backup.log \
-    && chown backup:backup /restores /var/cache/restic /var/log/backup.log
+    && chown backup:backup /restores /var/cache/restic
 
 USER backup
 ENTRYPOINT ["/entrypoint.sh"]

--- a/backup/crontab
+++ b/backup/crontab
@@ -1,1 +1,1 @@
-0 * * * * /backup.sh >> /var/log/backup.log 2>&1
+0 * * * * /backup.sh


### PR DESCRIPTION
**Changes:**
 * Remove shell I/O redirection from crontab so supercronic does not invoke a shell
 * Remove /var/log/backup.log creation and ownership from Dockerfile (no longer needed)