### PR TITLE
Fix ZAP "Unexpected Content-Type" alerts and CSP cleanup

### DIFF
--- a/backend/src/index.js
+++ b/backend/src/index.js
@@ -22,7 +22,7 @@ app.use(
     contentSecurityPolicy: {
       directives: {
         defaultSrc: ["'self'"],
-        scriptSrc: ["'self'", "'unsafe-inline'"], // unsafe-inline for dev if needed
+        scriptSrc: ["'self'"],
         styleSrc: ["'self'", "'unsafe-inline'"], // Tailwind needs inline styles
         imgSrc: ["'self'", 'data:', 'https:'], // OAuth avatars
         connectSrc: ["'self'"],
@@ -90,6 +90,11 @@ async function start() {
   app.use('/api/folders', requireAuth, foldersRouter);
   app.use('/api/account', requireAuth, accountRouter);
   app.use('/api', requireAuth, metaRouter);
+
+  // Catch-all: return JSON 404 for any unmatched route
+  app.use((_req, res) => {
+    res.status(404).json({ error: 'Not found' });
+  });
 
   // Central error handler for async routes
   const { errorHandler } = require('./middleware/error-handler');

--- a/backend/src/routes/auth.js
+++ b/backend/src/routes/auth.js
@@ -31,7 +31,7 @@ router.get('/google', (req, res, next) => {
 router.get(
   '/google/callback',
   (req, res, next) => {
-    if (!isEnabled('google')) return res.status(404).end();
+    if (!isEnabled('google')) return res.status(404).json({ error: 'Not found' });
     passport.authenticate('google', {
       failureRedirect: '/#/login?error=google',
       session: false,
@@ -87,7 +87,7 @@ router.get('/github', (req, res, next) => {
 router.get(
   '/github/callback',
   (req, res, next) => {
-    if (!isEnabled('github')) return res.status(404).end();
+    if (!isEnabled('github')) return res.status(404).json({ error: 'Not found' });
     passport.authenticate('github', {
       failureRedirect: '/#/login?error=github',
       session: false,
@@ -144,7 +144,7 @@ router.post(
   '/apple/callback',
   express.urlencoded({ extended: true }),
   (req, res, next) => {
-    if (!isEnabled('apple')) return res.status(404).end();
+    if (!isEnabled('apple')) return res.status(404).json({ error: 'Not found' });
     passport.authenticate('apple', {
       failureRedirect: '/#/login?error=apple',
       session: false,
@@ -200,7 +200,7 @@ router.get('/facebook', (req, res, next) => {
 router.get(
   '/facebook/callback',
   (req, res, next) => {
-    if (!isEnabled('facebook')) return res.status(404).end();
+    if (!isEnabled('facebook')) return res.status(404).json({ error: 'Not found' });
     passport.authenticate('facebook', {
       failureRedirect: '/#/login?error=facebook',
       session: false,


### PR DESCRIPTION
Closes https://github.com/luispabon/OpenFitLab/issues/107

**Changes:**
 * Add JSON catch-all 404 handler so unmatched routes return application/json instead of Express's default text/html (resolves 8 ZAP low-confidence alerts)
 * Replace bare res.status(404).end() in disabled OAuth callbacks with res.status(404).json({ error: 'Not found' }) for consistent Content-Type
 * Remove vestigial 'unsafe-inline' from Helmet scriptSrc CSP — the backend serves no HTML with inline scripts