### PR TITLE
Prefix env vars with OPENFITLAB_, use branch-based image tags, add dev-backup profile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@ REGISTRY       = ghcr.io/luispabon
 BACKEND_IMAGE  = $(REGISTRY)/openfitlab-backend
 FRONTEND_IMAGE = $(REGISTRY)/openfitlab-frontend
 BACKUP_IMAGE   = $(REGISTRY)/openfitlab-backup
-TAG ?= latest
+DOCKER_TAG ?= $(shell git rev-parse --abbrev-ref HEAD)
 
 # Re-initialise the database from scratch: remove DB volume, then start the stack.
 # The API runs db.initializeSchema() on startup, so the schema is applied to the fresh DB.
@@ -14,30 +14,30 @@ db-reset:
 
 .PHONY: docker-build-backend
 docker-build-backend:
-	docker build --target prod -t $(BACKEND_IMAGE):$(TAG) backend/
+	docker build --target prod -t $(BACKEND_IMAGE):$(DOCKER_TAG) backend/
 
 .PHONY: docker-build-frontend
 docker-build-frontend:
-	docker build --target prod -t $(FRONTEND_IMAGE):$(TAG) frontend/
+	docker build --target prod -t $(FRONTEND_IMAGE):$(DOCKER_TAG) frontend/
 
 .PHONY: docker-build-backup
 docker-build-backup:
-	docker build -t $(BACKUP_IMAGE):$(TAG) backup/
+	docker build -t $(BACKUP_IMAGE):$(DOCKER_TAG) backup/
 
 .PHONY: docker-build
 docker-build: docker-build-backend docker-build-frontend docker-build-backup
 
 .PHONY: docker-push-backend
 docker-push-backend: docker-build-backend
-	docker push $(BACKEND_IMAGE):$(TAG)
+	docker push $(BACKEND_IMAGE):$(DOCKER_TAG)
 
 .PHONY: docker-push-frontend
 docker-push-frontend: docker-build-frontend
-	docker push $(FRONTEND_IMAGE):$(TAG)
+	docker push $(FRONTEND_IMAGE):$(DOCKER_TAG)
 
 .PHONY: docker-push-backup
 docker-push-backup: docker-build-backup
-	docker push $(BACKUP_IMAGE):$(TAG)
+	docker push $(BACKUP_IMAGE):$(DOCKER_TAG)
 
 .PHONY: docker-push
 docker-push: docker-push-backend docker-push-frontend docker-push-backup

--- a/backup/crontab
+++ b/backup/crontab
@@ -1,1 +1,1 @@
-0 * * * * /backup.sh
+0 * * * * /bin/bash /backup.sh

--- a/compose.prod.yaml
+++ b/compose.prod.yaml
@@ -1,3 +1,4 @@
+---
 networks:
   # This network is exclusive of this stack for services to talk to each other internally.
   internal:
@@ -10,18 +11,21 @@ volumes:
   db_data:
   valkey_data:
   restores:
+  fake-gcs-storage:
 
 services:
   db:
     image: mariadb:12.2.2
     restart: unless-stopped
     environment:
-      MARIADB_ROOT_PASSWORD: ${MARIADB_ROOT_PASSWORD:?MARIADB_ROOT_PASSWORD is required}
-      MARIADB_DATABASE: ${MARIADB_DATABASE:-openfitlab}
-      MARIADB_USER: ${MARIADB_USER:-qs}
-      MARIADB_PASSWORD: ${MARIADB_PASSWORD:?MARIADB_PASSWORD is required}
+      MARIADB_ROOT_PASSWORD: ${OPENFITLAB_MARIADB_ROOT_PASSWORD:?OPENFITLAB_MARIADB_ROOT_PASSWORD is required}
+      MARIADB_DATABASE: ${OPENFITLAB_MARIADB_DATABASE:-openfitlab}
+      MARIADB_USER: ${OPENFITLAB_MARIADB_USER:-qs}
+      MARIADB_PASSWORD: ${OPENFITLAB_MARIADB_PASSWORD:?OPENFITLAB_MARIADB_PASSWORD is required}
     volumes:
       - db_data:/var/lib/mysql
+    networks:
+      - internal
     healthcheck:
       test: ["CMD", "healthcheck.sh", "--connect", "--innodb_initialized"]
       interval: 10s
@@ -34,6 +38,8 @@ services:
     restart: unless-stopped
     volumes:
       - valkey_data:/data
+    networks:
+      - internal
     healthcheck:
       test: ["CMD", "valkey-cli", "ping"]
       interval: 10s
@@ -42,28 +48,28 @@ services:
       start_period: 5s
 
   api:
-    image: ghcr.io/luispabon/openfitlab-backend:latest
+    image: ghcr.io/luispabon/openfitlab-backend:${OPENFITLAB_IMAGE_TAG:-main}
     restart: unless-stopped
     environment:
       PORT: 3000
       DB_HOST: db
-      DB_USER: ${MARIADB_USER:-qs}
-      DB_PASSWORD: ${MARIADB_PASSWORD:?MARIADB_PASSWORD is required}
-      DB_DATABASE: ${MARIADB_DATABASE:-openfitlab}
-      SESSION_SECRET: ${SESSION_SECRET:?SESSION_SECRET is required}
+      DB_USER: ${OPENFITLAB_MARIADB_USER:-qs}
+      DB_PASSWORD: ${OPENFITLAB_MARIADB_PASSWORD:?OPENFITLAB_MARIADB_PASSWORD is required}
+      DB_DATABASE: ${OPENFITLAB_MARIADB_DATABASE:-openfitlab}
+      SESSION_SECRET: ${OPENFITLAB_SESSION_SECRET:?OPENFITLAB_SESSION_SECRET is required}
       VALKEY_HOST: valkey
       VALKEY_PORT: 6379
-      GOOGLE_CLIENT_ID: ${GOOGLE_CLIENT_ID:-}
-      GOOGLE_CLIENT_SECRET: ${GOOGLE_CLIENT_SECRET:-}
-      GITHUB_CLIENT_ID: ${GITHUB_CLIENT_ID:-}
-      GITHUB_CLIENT_SECRET: ${GITHUB_CLIENT_SECRET:-}
-      APPLE_CLIENT_ID: ${APPLE_CLIENT_ID:-}
-      APPLE_TEAM_ID: ${APPLE_TEAM_ID:-}
-      APPLE_KEY_ID: ${APPLE_KEY_ID:-}
-      APPLE_PRIVATE_KEY: ${APPLE_PRIVATE_KEY:-}
-      FACEBOOK_APP_ID: ${FACEBOOK_APP_ID:-}
-      FACEBOOK_APP_SECRET: ${FACEBOOK_APP_SECRET:-}
-      OAUTH_CALLBACK_URL: ${OAUTH_CALLBACK_URL:?OAUTH_CALLBACK_URL is required}
+      GOOGLE_CLIENT_ID: ${OPENFITLAB_GOOGLE_CLIENT_ID:-}
+      GOOGLE_CLIENT_SECRET: ${OPENFITLAB_GOOGLE_CLIENT_SECRET:-}
+      GITHUB_CLIENT_ID: ${OPENFITLAB_GITHUB_CLIENT_ID:-}
+      GITHUB_CLIENT_SECRET: ${OPENFITLAB_GITHUB_CLIENT_SECRET:-}
+      APPLE_CLIENT_ID: ${OPENFITLAB_APPLE_CLIENT_ID:-}
+      APPLE_TEAM_ID: ${OPENFITLAB_APPLE_TEAM_ID:-}
+      APPLE_KEY_ID: ${OPENFITLAB_APPLE_KEY_ID:-}
+      APPLE_PRIVATE_KEY: ${OPENFITLAB_APPLE_PRIVATE_KEY:-}
+      FACEBOOK_APP_ID: ${OPENFITLAB_FACEBOOK_APP_ID:-}
+      FACEBOOK_APP_SECRET: ${OPENFITLAB_FACEBOOK_APP_SECRET:-}
+      OAUTH_CALLBACK_URL: ${OPENFITLAB_OAUTH_CALLBACK_URL:?OPENFITLAB_OAUTH_CALLBACK_URL is required}
     depends_on:
       db:
         condition: service_healthy
@@ -77,43 +83,47 @@ services:
       replicas: 2
     labels:
       - "traefik.enable=true"
-      - "traefik.http.routers.api.rule=Host(`${DOMAIN:?DOMAIN is required}`) && PathPrefix(`/api/`)"
+      - "traefik.docker.network=dmz"
+      - "traefik.http.routers.api.rule=Host(`${OPENFITLAB_DOMAIN:?OPENFITLAB_DOMAIN is required}`) && PathPrefix(`/api/`)"
       - "traefik.http.routers.api.entrypoints=web-secure"
       - "traefik.http.routers.api.tls.certresolver=lusa"
       - "traefik.http.services.api.loadbalancer.server.port=3000"
       - "com.centurylinklabs.watchtower.enable=true"
 
   frontend:
-    image: ghcr.io/luispabon/openfitlab-frontend:latest
+    image: ghcr.io/luispabon/openfitlab-frontend:${OPENFITLAB_IMAGE_TAG:-main}
     restart: unless-stopped
     networks:
       - dmz
     deploy:
       mode: replicated
       replicas: 2
-
     labels:
       - "traefik.enable=true"
-      - "traefik.http.routers.frontend.rule=Host(`${DOMAIN:?DOMAIN is required}`)"
+      - "traefik.http.routers.frontend.rule=Host(`${OPENFITLAB_DOMAIN:?OPENFITLAB_DOMAIN is required}`)"
       - "traefik.http.routers.frontend.entrypoints=web-secure"
       - "traefik.http.routers.frontend.tls.certresolver=lusa"
       - "traefik.http.services.frontend.loadbalancer.server.port=8080"
       - "com.centurylinklabs.watchtower.enable=true"
 
   backup:
-    image: ghcr.io/luispabon/openfitlab-backup:latest
+    image: ghcr.io/luispabon/openfitlab-backup:${OPENFITLAB_IMAGE_TAG:-main}
     restart: unless-stopped
+    init: true
     profiles:
       - backup
+    networks:
+      - internal
     environment:
       DB_HOST: db
-      DB_USER: ${MARIADB_USER:-qs}
-      DB_PASSWORD: ${MARIADB_PASSWORD:?MARIADB_PASSWORD is required}
-      DB_DATABASE: ${MARIADB_DATABASE:-openfitlab}
-      RESTIC_REPOSITORY: ${RESTIC_REPOSITORY:?RESTIC_REPOSITORY is required}
-      RESTIC_PASSWORD: ${RESTIC_PASSWORD:?RESTIC_PASSWORD is required}
-      GOOGLE_PROJECT_ID: ${GOOGLE_PROJECT_ID:?GOOGLE_PROJECT_ID is required}
+      DB_USER: ${OPENFITLAB_MARIADB_USER:-qs}
+      DB_PASSWORD: ${OPENFITLAB_MARIADB_PASSWORD:?OPENFITLAB_MARIADB_PASSWORD is required}
+      DB_DATABASE: ${OPENFITLAB_MARIADB_DATABASE:-openfitlab}
+      RESTIC_REPOSITORY: ${OPENFITLAB_RESTIC_REPOSITORY:?OPENFITLAB_RESTIC_REPOSITORY is required}
+      RESTIC_PASSWORD: ${OPENFITLAB_RESTIC_PASSWORD:?OPENFITLAB_RESTIC_PASSWORD is required}
+      GOOGLE_PROJECT_ID: ${OPENFITLAB_GOOGLE_PROJECT_ID:?OPENFITLAB_GOOGLE_PROJECT_ID is required}
       GOOGLE_APPLICATION_CREDENTIALS: /secrets/gcs-key.json
+      STORAGE_EMULATOR_HOST: ${OPENFITLAB_STORAGE_EMULATOR_HOST:-}
     volumes:
       - ./backup/secrets/gcs-key.json:/secrets/gcs-key.json:ro
       - restores:/restores
@@ -122,3 +132,27 @@ services:
         condition: service_healthy
     labels:
       - "com.centurylinklabs.watchtower.enable=true"
+
+  fake-gcs-init:
+    image: alpine:latest
+    profiles:
+      - dev-backup
+    command: mkdir -p /data/backup-openfitlab
+    networks:
+      - internal
+    volumes:
+      - fake-gcs-storage:/data
+
+  fake-gcs:
+    image: fsouza/fake-gcs-server:latest
+    profiles:
+      - dev-backup
+    command: -scheme http -port 4443 -filesystem-root /data -external-url http://fake-gcs:4443
+    depends_on:
+      fake-gcs-init:
+        condition: service_completed_successfully
+    networks:
+      - internal
+    volumes:
+      - fake-gcs-storage:/data
+    restart: unless-stopped


### PR DESCRIPTION
**Changes:**
 * Rename all env vars with OPENFITLAB_ prefix in compose.prod.yaml for namespacing
 * Switch image tags from hardcoded `latest` to `${OPENFITLAB_IMAGE_TAG:-main}` (dynamic per deploy)
 * Change Makefile TAG variable to DOCKER_TAG defaulting to current git branch name
 * Add `networks: internal` to db, valkey, and backup services
 * Add `traefik.docker.network=dmz` label to api service
 * Add `init: true` to backup service
 * Add fake-gcs-init and fake-gcs services under `dev-backup` profile for local backup testing
 * Add fake-gcs-storage volume
 * Fix backup crontab to use `/bin/bash /backup.sh` explicitly