### PR TITLE
Misc fixes: trust proxy, NODE_ENV, logo size, logout redirect, auth retry

### DIFF
--- a/backend/src/index.js
+++ b/backend/src/index.js
@@ -16,6 +16,11 @@ const metaRouter = require('./routes/meta');
 
 const app = express();
 
+// Trust proxy headers in production (Traefik sets X-Forwarded-* headers)
+if (config.server.isProduction) {
+  app.set('trust proxy', 1);
+}
+
 // Security headers
 app.use(
   helmet({

--- a/compose.prod.yaml
+++ b/compose.prod.yaml
@@ -52,6 +52,7 @@ services:
     restart: unless-stopped
     environment:
       PORT: 3000
+      NODE_ENV: production
       DB_HOST: db
       DB_USER: ${OPENFITLAB_MARIADB_USER:-qs}
       DB_PASSWORD: ${OPENFITLAB_MARIADB_PASSWORD:?OPENFITLAB_MARIADB_PASSWORD is required}

--- a/frontend/src/App.svelte
+++ b/frontend/src/App.svelte
@@ -156,9 +156,9 @@
       <!-- Logo/Branding -->
       <div class="flex items-center border-b border-border px-4 py-4">
         {#if sidebarCollapsed}
-          <img src={logoIcon} alt="OpenFitLab" class="h-8" />
+          <img src={logoIcon} alt="OpenFitLab" class="h-16" />
         {:else}
-          <img src={logoBig} alt="OpenFitLab" class="h-8" />
+          <img src={logoBig} alt="OpenFitLab" class="h-16" />
         {/if}
       </div>
 

--- a/frontend/src/lib/components/__tests__/user-menu.test.ts
+++ b/frontend/src/lib/components/__tests__/user-menu.test.ts
@@ -2,6 +2,8 @@ import { describe, it, expect, vi } from 'vitest';
 import { render, fireEvent } from '@testing-library/svelte';
 import UserMenu from '../../components/user-menu.svelte';
 
+vi.mock('svelte-spa-router', () => ({ push: vi.fn(), replace: vi.fn() }));
+
 describe('user-menu', () => {
   it('renders initials "U" when displayName is null', () => {
     const { getByText } = render(UserMenu, {
@@ -36,5 +38,17 @@ describe('user-menu', () => {
       '/api/auth/logout',
       expect.objectContaining({ method: 'POST', credentials: 'include' })
     );
+  });
+
+  it('calls replace("/") after logout', async () => {
+    const { replace } = await import('svelte-spa-router');
+    vi.spyOn(globalThis as unknown as { fetch: typeof fetch }, 'fetch').mockResolvedValue(
+      new Response(null, { status: 200 }) as unknown as Response
+    );
+    const { getByText } = render(UserMenu, {
+      props: { displayName: 'Alice', avatarUrl: null, collapsed: false },
+    });
+    await fireEvent.click(getByText('Logout'));
+    await vi.waitFor(() => expect(replace).toHaveBeenCalledWith('/'));
   });
 });

--- a/frontend/src/lib/components/user-menu.svelte
+++ b/frontend/src/lib/components/user-menu.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { push } from 'svelte-spa-router';
+  import { push, replace } from 'svelte-spa-router';
   import { logout } from '../stores/auth.svelte';
   const props = $props<{
     displayName: string | null;
@@ -35,9 +35,14 @@
         <button class="text-accent hover:underline" onclick={() => push('/account')} type="button">
           Account
         </button>
-        <button class="text-accent hover:underline" onclick={() => logout()} type="button">
-          Logout
-        </button>
+        <button
+          class="text-accent hover:underline"
+          onclick={async () => {
+            await logout();
+            replace('/');
+          }}
+          type="button">Logout</button
+        >
       </div>
     </div>
   {/if}

--- a/frontend/src/lib/stores/__tests__/auth.test.ts
+++ b/frontend/src/lib/stores/__tests__/auth.test.ts
@@ -1,5 +1,11 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { checkAuth, logout, state, setCurrentUser } from '../../stores/auth.svelte';
+import {
+  checkAuth,
+  logout,
+  state,
+  setCurrentUser,
+  urlHasSignupPending,
+} from '../../stores/auth.svelte';
 
 describe('auth store', () => {
   beforeEach(() => {
@@ -10,6 +16,7 @@ describe('auth store', () => {
     state.authLoading = true;
     state.pendingSignup = false;
     state.pendingProfile = null;
+    window.location.hash = '';
   });
 
   it('sets current user and csrfToken on successful /api/auth/me', async () => {
@@ -92,6 +99,45 @@ describe('auth store', () => {
 
     expect(state.user).toBeNull();
     expect(state.csrfToken).toBeNull();
+  });
+
+  it('urlHasSignupPending returns true when hash contains signup=pending or signup-pending', () => {
+    expect(urlHasSignupPending()).toBe(false);
+    window.location.hash = '#/?signup=pending';
+    expect(urlHasSignupPending()).toBe(true);
+    window.location.hash = '#/other?signup=pending';
+    expect(urlHasSignupPending()).toBe(true);
+    window.location.hash = '#/signup-pending';
+    expect(urlHasSignupPending()).toBe(true);
+    window.location.hash = '';
+    expect(urlHasSignupPending()).toBe(false);
+  });
+
+  it('retries /api/auth/me when 401 and URL has signup=pending then applies pendingSignup', async () => {
+    window.location.hash = '#/?signup=pending';
+    const fetchSpy = vi.spyOn(globalThis as unknown as { fetch: typeof fetch }, 'fetch');
+    fetchSpy
+      .mockResolvedValueOnce(new Response(null, { status: 401 }) as unknown as Response)
+      .mockResolvedValueOnce(
+        new Response(
+          JSON.stringify({
+            pendingSignup: true,
+            profile: { displayName: 'New User', avatarUrl: 'https://avatar' },
+            csrfToken: 'token-pending',
+          }),
+          { status: 200, headers: { 'Content-Type': 'application/json' } }
+        ) as unknown as Response
+      );
+
+    await checkAuth();
+
+    expect(fetchSpy).toHaveBeenCalledTimes(2);
+    expect(state.pendingSignup).toBe(true);
+    expect(state.pendingProfile).toEqual({
+      displayName: 'New User',
+      avatarUrl: 'https://avatar',
+    });
+    window.location.hash = '';
   });
 
   it('clears session on logout via apiFetch', async () => {

--- a/frontend/src/lib/stores/auth.svelte.ts
+++ b/frontend/src/lib/stores/auth.svelte.ts
@@ -34,31 +34,43 @@ export const state = $state({
   pendingProfile: null as PendingProfile | null,
 });
 
+export function urlHasSignupPending(): boolean {
+  const hash = window.location.hash;
+  return hash.includes('signup=pending') || hash.includes('signup-pending');
+}
+
+function applyAuthData(data: unknown) {
+  assertAuthResponse(data);
+  if (data.pendingSignup) {
+    state.pendingSignup = true;
+    state.pendingProfile = {
+      displayName: data.profile?.displayName ?? null,
+      avatarUrl: data.profile?.avatarUrl ?? null,
+    };
+    state.user = null;
+    state.csrfToken = data.csrfToken ?? null;
+  } else {
+    state.user = {
+      id: data.id ?? '',
+      displayName: data.displayName ?? null,
+      avatarUrl: data.avatarUrl ?? null,
+    };
+    state.csrfToken = data.csrfToken ?? null;
+    state.pendingSignup = false;
+    state.pendingProfile = null;
+  }
+}
+
 export async function checkAuth(): Promise<void> {
   try {
-    const res = await fetch('/api/auth/me', { credentials: 'include' });
+    let res = await fetch('/api/auth/me', { credentials: 'include' });
+    if (!res.ok && res.status === 401 && urlHasSignupPending()) {
+      await new Promise((r) => setTimeout(r, 500));
+      res = await fetch('/api/auth/me', { credentials: 'include' });
+    }
     if (res.ok) {
       const data = await res.json();
-      assertAuthResponse(data);
-
-      if (data.pendingSignup) {
-        state.pendingSignup = true;
-        state.pendingProfile = {
-          displayName: data.profile?.displayName ?? null,
-          avatarUrl: data.profile?.avatarUrl ?? null,
-        };
-        state.user = null;
-        state.csrfToken = data.csrfToken ?? null;
-      } else {
-        state.user = {
-          id: data.id ?? '',
-          displayName: data.displayName ?? null,
-          avatarUrl: data.avatarUrl ?? null,
-        };
-        state.csrfToken = data.csrfToken ?? null;
-        state.pendingSignup = false;
-        state.pendingProfile = null;
-      }
+      applyAuthData(data);
     } else {
       state.user = null;
       state.csrfToken = null;


### PR DESCRIPTION


**Changes:**
 * Set trust proxy when NODE_ENV=production so Traefik X-Forwarded-* headers are respected
 * Add NODE_ENV=production to compose.prod.yaml backend service
 * Increase sidebar logo height from h-8 to h-16
 * Navigate to "/" after logout using replace() instead of leaving stale route
 * Retry /api/auth/me once when 401 and URL signals a pending signup (race on OAuth callback)
 * Extract applyAuthData helper and export urlHasSignupPending for testability
 * Add tests for urlHasSignupPending, auth retry, and logout navigation