### PR TITLE
Preserve folder context in Back to Workouts navigation

### DIFF
--- a/frontend/src/lib/components/comparison/StreamAnalysisCard.svelte
+++ b/frontend/src/lib/components/comparison/StreamAnalysisCard.svelte
@@ -75,8 +75,10 @@
     {@const rating = getCorrelationRating(stats.r)}
     <div class="grid gap-6 lg:grid-cols-2">
       <!-- Scatter chart -->
-      <div>
-        <p class="mb-2 text-xs font-medium uppercase tracking-wider text-text-secondary">
+      <div class="flex flex-col">
+        <p
+          class="mb-2 flex min-h-[3rem] items-start text-xs font-medium uppercase tracking-wider text-text-secondary"
+        >
           Scatter / Correlation
           <span
             class="ml-2 inline-flex flex-col items-center rounded px-2 py-0.5 leading-tight align-middle"
@@ -100,8 +102,10 @@
       </div>
 
       <!-- Delta chart -->
-      <div>
-        <p class="mb-2 text-xs font-medium uppercase tracking-wider text-text-secondary">
+      <div class="flex flex-col">
+        <p
+          class="mb-2 flex min-h-[3rem] items-start text-xs font-medium uppercase tracking-wider text-text-secondary"
+        >
           Delta over time ({secDeviceName} − {refDeviceName})
         </p>
         <DeltaChart

--- a/frontend/src/routes/__tests__/event-detail.test.ts
+++ b/frontend/src/routes/__tests__/event-detail.test.ts
@@ -86,7 +86,7 @@ describe('EventDetail', () => {
     expect(screen.getByText(/1:00:00/)).toBeInTheDocument();
   });
 
-  it('Back to Workouts button calls push("/")', async () => {
+  it('Back to Workouts button calls push("/") when no back param', async () => {
     mockGetEvent.mockResolvedValue(eventDetailFixture);
     render(EventDetail, { props: { params: { id: 'evt-1' } } });
     await waitFor(() => {
@@ -94,6 +94,28 @@ describe('EventDetail', () => {
     });
     await fireEvent.click(screen.getByRole('button', { name: '← Back to Workouts' }));
     expect(mockPush).toHaveBeenCalledWith('/');
+  });
+
+  it('Back to Workouts button restores folder when back param is set via query prop', async () => {
+    mockGetEvent.mockResolvedValue(eventDetailFixture);
+    render(EventDetail, { props: { params: { id: 'evt-1' }, query: { back: 'folder-123' } } });
+    await waitFor(() => {
+      expect(screen.getByText('Morning Run')).toBeInTheDocument();
+    });
+    await fireEvent.click(screen.getByRole('button', { name: '← Back to Workouts' }));
+    expect(mockPush).toHaveBeenCalledWith('#/?folder=folder-123');
+  });
+
+  it('Back to Workouts button restores folder when back param is in window.location.hash', async () => {
+    vi.stubGlobal('location', { hash: '#/event/evt-1?back=folder-123' });
+    mockGetEvent.mockResolvedValue(eventDetailFixture);
+    render(EventDetail, { props: { params: { id: 'evt-1' } } });
+    await waitFor(() => {
+      expect(screen.getByText('Morning Run')).toBeInTheDocument();
+    });
+    await fireEvent.click(screen.getByRole('button', { name: '← Back to Workouts' }));
+    expect(mockPush).toHaveBeenCalledWith('#/?folder=folder-123');
+    vi.unstubAllGlobals();
   });
 
   it('when id is missing shows Event not found', () => {

--- a/frontend/src/routes/__tests__/workouts.test.ts
+++ b/frontend/src/routes/__tests__/workouts.test.ts
@@ -131,13 +131,23 @@ describe('Workouts', () => {
     });
   });
 
-  it('pushes to event detail when row View is clicked', async () => {
+  it('pushes to event detail when row View is clicked (no folder)', async () => {
     render(Workouts);
     await waitFor(() => {
       expect(screen.getByRole('button', { name: 'View' })).toBeInTheDocument();
     });
     await fireEvent.click(screen.getByRole('button', { name: 'View' }));
     expect(mockPush).toHaveBeenCalledWith('/event/evt-1');
+  });
+
+  it('includes back param when row View is clicked inside a folder', async () => {
+    setFolderHash('#/?folder=folder-123');
+    render(Workouts);
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: 'View' })).toBeInTheDocument();
+    });
+    await fireEvent.click(screen.getByRole('button', { name: 'View' }));
+    expect(mockPush).toHaveBeenCalledWith('/event/evt-1?back=folder-123');
   });
 
   it('opens single-delete flow when row Delete is clicked', async () => {

--- a/frontend/src/routes/event-detail.svelte
+++ b/frontend/src/routes/event-detail.svelte
@@ -1,8 +1,9 @@
 <script lang="ts">
   interface Props {
     params?: { id?: string };
+    query?: { back?: string };
   }
-  let { params = {} }: Props = $props();
+  let { params = {}, query = {} }: Props = $props();
 
   import { push } from 'svelte-spa-router';
   import { getEvent, getStreams, getActivityTypes, getDevices, updateActivity } from '../lib/api';
@@ -27,8 +28,22 @@
   import StatCard from '../lib/components/StatCard.svelte';
   import EventDetailMoreStats from '../lib/components/event-detail/EventDetailMoreStats.svelte';
   import EventDetailStreamCharts from '../lib/components/event-detail/EventDetailStreamCharts.svelte';
+  import { buildFolderHash } from '../lib/stores/folders.svelte';
 
   const id = $derived(params?.id ?? '');
+
+  let backFolderId = $state<string | null>(null);
+
+  $effect(() => {
+    if (query?.back?.trim()) {
+      backFolderId = query.back.trim();
+      return;
+    }
+    const match = window.location.hash.match(/[?&]back=([^&]*)/);
+    backFolderId = match?.[1] ? decodeURIComponent(match[1]).trim() || null : null;
+  });
+
+  const backPath = $derived(backFolderId ? buildFolderHash(backFolderId) : '/');
 
   let eventDetail = $state<EventDetailType | null>(null);
   let loading = $state(true);
@@ -389,7 +404,7 @@
   <button
     type="button"
     class="mb-4 rounded border border-border px-3 py-1.5 text-base text-text-secondary hover:bg-card-hover hover:text-text-primary"
-    onclick={() => push('/')}
+    onclick={() => push(backPath)}
   >
     ← Back to Workouts
   </button>

--- a/frontend/src/routes/workouts.svelte
+++ b/frontend/src/routes/workouts.svelte
@@ -248,6 +248,11 @@
     }
   }
 
+  function eventPath(id: string): string {
+    const back = activeFolderId !== 'all' ? `?back=${encodeURIComponent(activeFolderId)}` : '';
+    return `/event/${id}${back}`;
+  }
+
   function handleDeleteClick(eventId: string, event: MouseEvent) {
     event.stopPropagation();
     eventToDelete = eventId;
@@ -451,11 +456,11 @@
         {formatCaloriesCell}
         {formatDistanceCell}
         onSelectAllChange={toggleSelectAll}
-        onRowClick={(id) => push(`/event/${id}`)}
+        onRowClick={(id) => push(eventPath(id))}
         onToggleEventSelection={toggleEventSelection}
         onViewClick={(id, e) => {
           e.stopPropagation();
-          push(`/event/${id}`);
+          push(eventPath(id));
         }}
         onFindComparisonsClick={(id) => compareCandidatesFlow?.openForEvent(id)}
         onMoveClick={(id, e) => {


### PR DESCRIPTION
**Changes:**
 * Add eventPath() helper in workouts.svelte to append ?back=<folderId> when a folder is active
 * Read back param from window.location.hash in event-detail (router does not pass query as a prop)
 * Fall back to query prop for testability (mirrors comparison-view pattern)
 * Add tests for folder back-navigation in workouts and event-detail, including the hash-parsing code path