### PR TITLE
Add Activity Date column to saved comparisons list

### DIFF
--- a/backend/src/repositories/comparison-repository.js
+++ b/backend/src/repositories/comparison-repository.js
@@ -1,5 +1,18 @@
 const { runQuery, placeholders } = require('./query-helper');
 
+/** Resolve reference activity ID from comparison row (settings + activity_ids). */
+function getReferenceActivityId(row) {
+  const activityIds = row.activity_ids || [];
+  if (activityIds.length === 0) return null;
+  let refId = null;
+  if (row.settings != null) {
+    const settings = typeof row.settings === 'string' ? JSON.parse(row.settings) : row.settings;
+    refId = settings?.referenceActivityId ?? null;
+  }
+  if (refId && activityIds.includes(refId)) return refId;
+  return activityIds[0];
+}
+
 async function create(id, name, activityRows, settings, opts = {}) {
   if (!opts.userId) throw new Error('create comparison requires opts.userId');
   const folderId = opts.folderId != null && opts.folderId !== '' ? opts.folderId : null;
@@ -73,11 +86,33 @@ async function findAll(limit, opts = {}) {
     activityIdsByComparison[link.comparison_id].push(link.activity_id);
   }
 
-  return comparisons.map((row) => ({
-    ...row,
-    event_ids: eventIdsByComparison[row.id] || [],
-    activity_ids: activityIdsByComparison[row.id] || [],
-  }));
+  const allActivityIds = [...new Set(Object.values(activityIdsByComparison).flat())];
+  let startDateByActivityId = {};
+  if (allActivityIds.length > 0) {
+    const activityRows = await runQuery(
+      `SELECT id, start_date FROM activities WHERE id IN (${placeholders(allActivityIds.length)})`,
+      allActivityIds,
+      opts
+    );
+    const arr = Array.isArray(activityRows) ? activityRows : [];
+    startDateByActivityId = Object.fromEntries(arr.map((r) => [r.id, r.start_date]));
+  }
+
+  return comparisons.map((row) => {
+    const activityIds = activityIdsByComparison[row.id] || [];
+    const rowWithIds = {
+      ...row,
+      event_ids: eventIdsByComparison[row.id] || [],
+      activity_ids: activityIds,
+    };
+    const refActivityId = getReferenceActivityId(rowWithIds);
+    const reference_activity_start_date =
+      refActivityId != null ? (startDateByActivityId[refActivityId] ?? null) : null;
+    return {
+      ...rowWithIds,
+      reference_activity_start_date,
+    };
+  });
 }
 
 /**
@@ -128,11 +163,33 @@ async function findAllForFolder(folderId, limit, opts = {}) {
     activityIdsByComparison[link.comparison_id].push(link.activity_id);
   }
 
-  return comparisons.map((row) => ({
-    ...row,
-    event_ids: eventIdsByComparison[row.id] || [],
-    activity_ids: activityIdsByComparison[row.id] || [],
-  }));
+  const allActivityIds = [...new Set(Object.values(activityIdsByComparison).flat())];
+  let startDateByActivityId = {};
+  if (allActivityIds.length > 0) {
+    const activityRows = await runQuery(
+      `SELECT id, start_date FROM activities WHERE id IN (${placeholders(allActivityIds.length)})`,
+      allActivityIds,
+      opts
+    );
+    const arr = Array.isArray(activityRows) ? activityRows : [];
+    startDateByActivityId = Object.fromEntries(arr.map((r) => [r.id, r.start_date]));
+  }
+
+  return comparisons.map((row) => {
+    const activityIds = activityIdsByComparison[row.id] || [];
+    const rowWithIds = {
+      ...row,
+      event_ids: eventIdsByComparison[row.id] || [],
+      activity_ids: activityIds,
+    };
+    const refActivityId = getReferenceActivityId(rowWithIds);
+    const reference_activity_start_date =
+      refActivityId != null ? (startDateByActivityId[refActivityId] ?? null) : null;
+    return {
+      ...rowWithIds,
+      reference_activity_start_date,
+    };
+  });
 }
 
 async function findById(id, opts = {}) {
@@ -156,6 +213,21 @@ async function findById(id, opts = {}) {
   } else {
     row.event_ids = [];
     row.activity_ids = [];
+  }
+  const activityIds = row.activity_ids || [];
+  if (activityIds.length > 0) {
+    const activityRows = await runQuery(
+      `SELECT id, start_date FROM activities WHERE id IN (${placeholders(activityIds.length)})`,
+      activityIds,
+      opts
+    );
+    const arr = Array.isArray(activityRows) ? activityRows : [];
+    const startDateByActivityId = Object.fromEntries(arr.map((r) => [r.id, r.start_date]));
+    const refActivityId = getReferenceActivityId(row);
+    row.reference_activity_start_date =
+      refActivityId != null ? (startDateByActivityId[refActivityId] ?? null) : null;
+  } else {
+    row.reference_activity_start_date = null;
   }
   return row;
 }

--- a/backend/src/services/comparison-service.js
+++ b/backend/src/services/comparison-service.js
@@ -78,6 +78,10 @@ async function getComparisons(limit = 100, opts = {}) {
     const eventFolderIds = folderIdsByComparison[row.id];
     const mixed = eventFolderIds ? eventFolderIds.size > 1 : false;
     const surfaced = Boolean(folderId && row.folder_id !== folderId);
+    const referenceActivityStartDate =
+      row.reference_activity_start_date != null
+        ? Number(row.reference_activity_start_date)
+        : undefined;
     return {
       id: row.id,
       name: row.name,
@@ -88,6 +92,7 @@ async function getComparisons(limit = 100, opts = {}) {
       mixed,
       surfaced,
       createdAt: row.created_at ? new Date(row.created_at).getTime() : undefined,
+      referenceActivityStartDate,
     };
   });
 }
@@ -109,6 +114,10 @@ async function getComparisonById(id, opts = {}) {
   );
   const eventFolderIds = folderIdsByComparison[id];
   const mixed = eventFolderIds ? eventFolderIds.size > 1 : false;
+  const referenceActivityStartDate =
+    row.reference_activity_start_date != null
+      ? Number(row.reference_activity_start_date)
+      : undefined;
   return {
     id: row.id,
     name: row.name,
@@ -118,6 +127,7 @@ async function getComparisonById(id, opts = {}) {
     folderId: row.folder_id ?? null,
     mixed,
     createdAt: row.created_at ? new Date(row.created_at).getTime() : undefined,
+    referenceActivityStartDate,
   };
 }
 

--- a/backend/test/unit/services/comparison-service.test.js
+++ b/backend/test/unit/services/comparison-service.test.js
@@ -109,6 +109,7 @@ describe('comparison-service', () => {
             return [
               {
                 id: 'c1',
+                folder_id: null,
                 name: 'C1',
                 settings: '{}',
                 created_at: new Date('2025-01-01T00:00:00Z'),
@@ -119,6 +120,12 @@ describe('comparison-service', () => {
             return [
               { comparison_id: 'c1', event_id: 'e1', activity_id: 'a1' },
               { comparison_id: 'c1', event_id: 'e2', activity_id: 'a2' },
+            ];
+          }
+          if (sql.includes('FROM activities')) {
+            return [
+              { id: 'a1', start_date: 1704067200000 },
+              { id: 'a2', start_date: 1704153600000 },
             ];
           }
           return [];
@@ -134,6 +141,7 @@ describe('comparison-service', () => {
       deepStrictEqual(result[0].activityIds, ['a1', 'a2']);
       deepStrictEqual(result[0].settings, {});
       strictEqual(result[0].createdAt, new Date('2025-01-01T00:00:00Z').getTime());
+      strictEqual(result[0].referenceActivityStartDate, 1704067200000);
     });
 
     it('returns empty array when no comparisons exist', async () => {
@@ -157,6 +165,7 @@ describe('comparison-service', () => {
             return [
               {
                 id: 'c1',
+                folder_id: null,
                 name: 'C1',
                 settings: null,
                 created_at: new Date('2025-01-01T00:00:00Z'),
@@ -169,6 +178,12 @@ describe('comparison-service', () => {
               { event_id: 'e2', activity_id: 'a2' },
             ];
           }
+          if (sql.includes('FROM activities')) {
+            return [
+              { id: 'a1', start_date: 1704067200000 },
+              { id: 'a2', start_date: 1704153600000 },
+            ];
+          }
           return [];
         },
       };
@@ -179,6 +194,7 @@ describe('comparison-service', () => {
       deepStrictEqual(result.eventIds, ['e1', 'e2']);
       deepStrictEqual(result.activityIds, ['a1', 'a2']);
       strictEqual(result.settings, null);
+      strictEqual(result.referenceActivityStartDate, 1704067200000);
     });
   });
 

--- a/frontend/src/lib/types/event.ts
+++ b/frontend/src/lib/types/event.ts
@@ -120,4 +120,6 @@ export interface Comparison {
   mixed?: boolean;
   /** True when comparison is shown in a folder view because it references an event in that folder (home folder may differ). */
   surfaced?: boolean;
+  /** Start date (ms) of the reference device activity. */
+  referenceActivityStartDate?: number;
 }

--- a/frontend/src/routes/__tests__/comparisons.test.ts
+++ b/frontend/src/routes/__tests__/comparisons.test.ts
@@ -57,6 +57,20 @@ describe('Comparisons', () => {
     expect(screen.getByText(/Nov 14, 2023/)).toBeInTheDocument();
   });
 
+  it('shows Activity Date column and reference activity date when present', async () => {
+    const withRefDate = {
+      ...comparisonFixture,
+      referenceActivityStartDate: 1704067200000,
+    };
+    mockGetComparisons.mockResolvedValue([withRefDate]);
+    render(Comparisons);
+    await waitFor(() => {
+      expect(screen.getByText('Run vs Ride')).toBeInTheDocument();
+    });
+    expect(screen.getByText('Activity Date')).toBeInTheDocument();
+    expect(screen.getByText('Jan 1, 2024')).toBeInTheDocument();
+  });
+
   it('navigates to compare view when row is clicked', async () => {
     mockGetComparisons.mockResolvedValue([comparisonFixture]);
     render(Comparisons);

--- a/frontend/src/routes/comparisons.svelte
+++ b/frontend/src/routes/comparisons.svelte
@@ -287,6 +287,12 @@
               scope="col"
               class="px-6 py-3 text-left text-xs font-medium uppercase tracking-wider text-text-secondary"
             >
+              Activity Date
+            </th>
+            <th
+              scope="col"
+              class="px-6 py-3 text-left text-xs font-medium uppercase tracking-wider text-text-secondary"
+            >
               Created
             </th>
             <th scope="col" class="relative px-6 py-3">
@@ -360,6 +366,9 @@
                     {getFolderLabel(comparison)}
                   </button>
                 {/if}
+              </td>
+              <td class="px-6 py-4 text-text-secondary">
+                {formatDate(comparison.referenceActivityStartDate)}
               </td>
               <td class="px-6 py-4 text-text-secondary">{formatDate(comparison.createdAt)}</td>
               <td class="whitespace-nowrap px-6 py-4 text-right font-medium">


### PR DESCRIPTION
**Changes:**
 * Add reference activity start date to comparison repo (findAll, findAllForFolder, findById)
 * Expose referenceActivityStartDate in comparison service getComparisons and getComparisonById
 * Add referenceActivityStartDate to Comparison type and Activity Date column in comparisons.svelte
 * Extend backend and frontend tests for new field and column
