### PR TITLE
Fix comparison table folder dropdown clipped by overflow

### DIFF
--- a/frontend/src/lib/components/SearchableSelect.svelte
+++ b/frontend/src/lib/components/SearchableSelect.svelte
@@ -16,9 +16,34 @@
     oncancel,
   }: Props = $props();
 
+  let rootEl = $state<HTMLDivElement | null>(null);
   let inputEl = $state<HTMLInputElement | null>(null);
+  let listboxEl = $state<HTMLDivElement | null>(null);
   let query = $state('');
   let highlightedIndex = $state(0);
+  let dropdownStyle = $state('');
+
+  function updateDropdownPosition() {
+    if (!rootEl || !listboxEl) return;
+    const rect = rootEl.getBoundingClientRect();
+    const maxHeight = 240; // max-h-60 = 15rem = 240px
+    const spaceBelow = window.innerHeight - rect.bottom;
+    const spaceAbove = rect.top;
+
+    let top: number;
+    let maxH: number;
+
+    // Position below if there's enough space, otherwise above
+    if (spaceBelow >= maxHeight || spaceBelow >= spaceAbove) {
+      top = rect.bottom;
+      maxH = Math.min(maxHeight, spaceBelow - 8);
+    } else {
+      maxH = Math.min(maxHeight, spaceAbove - 8);
+      top = rect.top - maxH - 4;
+    }
+
+    dropdownStyle = `position: fixed; top: ${top}px; left: ${rect.left}px; width: ${rect.width}px; max-height: ${maxH}px;`;
+  }
 
   $effect(() => {
     query = value;
@@ -74,7 +99,10 @@
 
   function handleClickOutside(e: MouseEvent) {
     const target = e.target as Node;
-    if (inputEl && !inputEl.closest('.searchable-select-root')?.contains(target)) {
+    // Check both root (contains input) and listbox since listbox uses fixed position outside root
+    const isInsideRoot = rootEl?.contains(target);
+    const isInsideListbox = listboxEl?.contains(target);
+    if (!isInsideRoot && !isInsideListbox) {
       oncancel();
     }
   }
@@ -98,9 +126,29 @@
     void displayList.length;
     highlightedIndex = 0;
   });
+
+  // Update dropdown position when it renders
+  $effect(() => {
+    if (listboxEl) {
+      updateDropdownPosition();
+    }
+  });
+
+  // Listen for scroll/resize to update position
+  $effect(() => {
+    const handler = () => {
+      if (listboxEl) updateDropdownPosition();
+    };
+    window.addEventListener('scroll', handler, true);
+    window.addEventListener('resize', handler);
+    return () => {
+      window.removeEventListener('scroll', handler, true);
+      window.removeEventListener('resize', handler);
+    };
+  });
 </script>
 
-<div class="searchable-select-root relative w-full min-w-[12rem]">
+<div bind:this={rootEl} class="searchable-select-root relative w-full min-w-[12rem]">
   <input
     bind:this={inputEl}
     type="text"
@@ -113,33 +161,37 @@
     aria-controls="searchable-select-listbox"
     aria-autocomplete="list"
   />
-  <div
-    id="searchable-select-listbox"
-    role="listbox"
-    class="absolute top-full left-0 z-50 mt-1 max-h-60 w-full overflow-auto rounded-lg border border-border bg-surface-solid shadow-lg"
-  >
-    {#if displayList.length === 0 && !canCommitCustom}
-      <div class="px-3 py-2 text-sm text-text-muted">No matches</div>
-    {:else}
-      {#each displayList as opt, i (opt + String(i))}
-        <button
-          type="button"
-          role="option"
-          aria-selected={i === highlightedIndex}
-          class="w-full px-3 py-2 text-left text-sm transition-colors {i === highlightedIndex
-            ? 'bg-card-hover-solid text-text-primary'
-            : 'text-text-primary hover:bg-card-solid'}"
-          onmouseenter={() => (highlightedIndex = i)}
-          onmousedown={(e) => e.preventDefault()}
-          onclick={() => commit(opt)}
-        >
-          {#if showCustomHint && i === 0}
-            <span class="text-text-secondary">Use “{opt}”</span>
-          {:else}
-            {opt}
-          {/if}
-        </button>
-      {/each}
-    {/if}
-  </div>
+</div>
+
+<!-- Fixed-positioned dropdown that breaks out of overflow:hidden containers -->
+<div
+  bind:this={listboxEl}
+  id="searchable-select-listbox"
+  role="listbox"
+  class="z-[9999] overflow-auto rounded-lg border border-border bg-surface-solid shadow-lg"
+  style={dropdownStyle}
+>
+  {#if displayList.length === 0 && !canCommitCustom}
+    <div class="px-3 py-2 text-sm text-text-muted">No matches</div>
+  {:else}
+    {#each displayList as opt, i (opt + String(i))}
+      <button
+        type="button"
+        role="option"
+        aria-selected={i === highlightedIndex}
+        class="w-full px-3 py-2 text-left text-sm transition-colors {i === highlightedIndex
+          ? 'bg-card-hover-solid text-text-primary'
+          : 'text-text-primary hover:bg-card-solid'}"
+        onmouseenter={() => (highlightedIndex = i)}
+        onmousedown={(e) => e.preventDefault()}
+        onclick={() => commit(opt)}
+      >
+        {#if showCustomHint && i === 0}
+          <span class="text-text-secondary">Use "{opt}"</span>
+        {:else}
+          {opt}
+        {/if}
+      </button>
+    {/each}
+  {/if}
 </div>


### PR DESCRIPTION
**Changes:**
 * Use position: fixed for SearchableSelect dropdown so it escapes overflow:hidden
 * Position dropdown via getBoundingClientRect; update on scroll/resize
 * Place above input when space below is insufficient
 * Update click-outside to include detached dropdown element