### PR TITLE
Add links to original events from comparison view

### DIFF
--- a/frontend/src/lib/components/comparison/ComparisonStatsTable.svelte
+++ b/frontend/src/lib/components/comparison/ComparisonStatsTable.svelte
@@ -17,6 +17,8 @@
     ) => { absolute: number; percent: number } | null;
     onHideStat?: (statType: string) => void;
     referenceEventId?: string;
+    /** When set, each event column header shows a link to view the original event. */
+    onNavigateToEvent?: (eventId: string) => void;
   }
   let {
     events,
@@ -27,6 +29,7 @@
     calculateDelta,
     onHideStat,
     referenceEventId,
+    onNavigateToEvent,
   }: Props = $props();
 
   // Index of the reference event in the events array
@@ -87,15 +90,28 @@
               class="px-6 py-3 text-left text-xs font-medium uppercase tracking-wider text-text-secondary"
               style="border-left: 2px solid {color};"
             >
-              {activity
-                ? getActivityDeviceName(activity)
-                : eventDetail.event.name || `Event ${originalIndex + 1}`}
-              {#if isRef}
-                <span
-                  class="ml-1 rounded px-1 py-0.5 text-[10px] font-semibold uppercase tracking-wide"
-                  style="background-color: #ef444426; color: #ef4444;">Ref</span
-                >
-              {/if}
+              <span class="inline-flex items-center gap-1">
+                {activity
+                  ? getActivityDeviceName(activity)
+                  : eventDetail.event.name || `Event ${originalIndex + 1}`}
+                {#if onNavigateToEvent}
+                  <button
+                    type="button"
+                    class="rounded p-0.5 text-text-muted hover:bg-accent/10 hover:text-accent focus:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-accent"
+                    title="View original event"
+                    aria-label="View original event"
+                    onclick={() => onNavigateToEvent(eventId)}
+                  >
+                    <span class="material-icons text-sm" aria-hidden="true">open_in_new</span>
+                  </button>
+                {/if}
+                {#if isRef}
+                  <span
+                    class="rounded px-1 py-0.5 text-[10px] font-semibold uppercase tracking-wide"
+                    style="background-color: #ef444426; color: #ef4444;">Ref</span
+                  >
+                {/if}
+              </span>
             </th>
             {#if showDeltas && !isRef}
               <th

--- a/frontend/src/routes/__tests__/comparison-view.test.ts
+++ b/frontend/src/routes/__tests__/comparison-view.test.ts
@@ -429,6 +429,41 @@ describe('ComparisonView', () => {
     expect(nameInput).toHaveValue('running / Garmin Forerunner 945 vs Wahoo Elemnt');
   });
 
+  it('Reference Device section shows "View original event" links that navigate with back param', async () => {
+    render(ComparisonView, {
+      props: { params: { id: 'new' }, query: { events: 'evt-1,evt-2' } },
+    });
+    await waitFor(() => {
+      expect(
+        screen.getByText('running / Garmin Forerunner 945 vs Wahoo Elemnt')
+      ).toBeInTheDocument();
+    });
+    const viewEventButtons = screen.getAllByRole('button', {
+      name: 'View original event',
+    });
+    expect(viewEventButtons.length).toBeGreaterThanOrEqual(2);
+    await fireEvent.click(viewEventButtons[0]);
+    expect(mockPush).toHaveBeenCalledWith(
+      '/event/evt-1?back=' + encodeURIComponent('/compare/new?events=evt-1,evt-2')
+    );
+  });
+
+  it('saved comparison event link includes back path to comparison', async () => {
+    mockGetComparison.mockResolvedValue(comparisonFixture);
+    render(ComparisonView, { props: { params: { id: 'cmp-1' } } });
+    await waitFor(() => {
+      expect(screen.getByText('Run vs Ride')).toBeInTheDocument();
+    });
+    const viewEventButtons = screen.getAllByRole('button', {
+      name: 'View original event',
+    });
+    expect(viewEventButtons.length).toBeGreaterThanOrEqual(2);
+    await fireEvent.click(viewEventButtons[0]);
+    expect(mockPush).toHaveBeenCalledWith(
+      '/event/evt-1?back=' + encodeURIComponent('/compare/cmp-1')
+    );
+  });
+
   it('when first device activity is "Other", uses second device activity type for name prefix', async () => {
     const evt1Other = {
       ...eventDetailFixture,

--- a/frontend/src/routes/comparison-view.svelte
+++ b/frontend/src/routes/comparison-view.svelte
@@ -156,6 +156,15 @@
 
   // Reference activity / event ID derived from loader state
   const referenceActivityId = $derived(loaderState.referenceActivityId);
+  // Back path for event links: return to this comparison when user clicks Back on event detail
+  const comparisonBackPath = $derived(
+    savedComparison
+      ? `/compare/${savedComparison.id}`
+      : eventIds.length > 0
+        ? `/compare/new?events=${eventIds.join(',')}`
+        : '/compare/new'
+  );
+
   const referenceEventId = $derived.by(() => {
     const refActId = referenceActivityId;
     if (!refActId) {
@@ -680,23 +689,39 @@
             : eventDetail.event.name || `Event ${i + 1}`}
           {@const isRef = referenceEventId === eventId}
           {@const color = EVENT_COLORS[i % EVENT_COLORS.length]}
-          <button
-            type="button"
+          <div
             class="flex items-center gap-2 rounded-full border px-3 py-1.5 text-sm transition-colors {isRef
               ? 'text-text-primary'
-              : 'border-border bg-transparent text-text-secondary hover:bg-card-hover'}"
+              : 'border-border bg-transparent text-text-secondary'}"
             style={isRef ? `background-color: ${color}20; border-color: ${color}80` : ''}
-            onclick={() => activityId && handleReferenceChange(activityId)}
           >
-            <span class="h-2 w-2 rounded-full" style="background-color: {color};"></span>
-            {deviceName}
-            {#if isRef}
-              <span
-                class="rounded bg-accent/15 px-1 py-0.5 text-[10px] font-semibold uppercase tracking-wide text-accent"
-                >Ref</span
-              >
-            {/if}
-          </button>
+            <button
+              type="button"
+              class="flex items-center gap-2 rounded-full -m-1.5 p-1.5 text-inherit hover:opacity-90 focus:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-accent {!isRef
+                ? 'hover:bg-card-hover'
+                : ''}"
+              onclick={() => activityId && handleReferenceChange(activityId)}
+            >
+              <span class="h-2 w-2 rounded-full" style="background-color: {color};"></span>
+              {deviceName}
+              {#if isRef}
+                <span
+                  class="rounded bg-accent/15 px-1 py-0.5 text-[10px] font-semibold uppercase tracking-wide text-accent"
+                  >Ref</span
+                >
+              {/if}
+            </button>
+            <button
+              type="button"
+              class="rounded p-0.5 text-text-muted hover:bg-accent/10 hover:text-accent focus:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-accent"
+              title="View original event"
+              aria-label="View original event"
+              onclick={() =>
+                push(`/event/${eventId}?back=${encodeURIComponent(comparisonBackPath)}`)}
+            >
+              <span class="material-icons text-sm" aria-hidden="true">open_in_new</span>
+            </button>
+          </div>
         {/each}
       </div>
     </div>
@@ -742,6 +767,8 @@
       {calculateDelta}
       onHideStat={toggleHiddenStat}
       referenceEventId={referenceEventId ?? undefined}
+      onNavigateToEvent={(eventId) =>
+        push(`/event/${eventId}?back=${encodeURIComponent(comparisonBackPath)}`)}
     />
 
     <!-- Comparison map: all devices' routes with EVENT_COLORS -->

--- a/frontend/src/routes/event-detail.svelte
+++ b/frontend/src/routes/event-detail.svelte
@@ -43,7 +43,14 @@
     backFolderId = match?.[1] ? decodeURIComponent(match[1]).trim() || null : null;
   });
 
-  const backPath = $derived(backFolderId ? buildFolderHash(backFolderId) : '/');
+  // If back is a path (e.g. /compare/123), use it directly; otherwise treat as folder id
+  const backPath = $derived(
+    !backFolderId
+      ? '/'
+      : backFolderId.startsWith('/')
+        ? backFolderId
+        : buildFolderHash(backFolderId)
+  );
 
   let eventDetail = $state<EventDetailType | null>(null);
   let loading = $state(true);


### PR DESCRIPTION
**Changes:**
 * Add "View original event" icon in Reference Device box; each device links to /event/{id} with back param
 * Add optional onNavigateToEvent to ComparisonStatsTable; show link icon in event column headers
 * Event detail: treat back query as path when it starts with / (return to comparison)
 * Tests: verify event links render and push correct URL for new and saved comparisons