### PR TITLE
Fix stale device names in comparison view after editing event

### DIFF
--- a/frontend/src/lib/utils/comparison-loader.svelte.ts
+++ b/frontend/src/lib/utils/comparison-loader.svelte.ts
@@ -173,6 +173,15 @@ async function loadEventsAndStreams(
 }
 
 /**
+ * Force a fresh load (e.g. when returning from event detail after edits).
+ * Resets the loaded key so the next load() will re-fetch.
+ */
+export function reload(comparisonId: string, eventIdsFromQuery: string[]): void {
+  lastLoadedKey = '';
+  load(comparisonId, eventIdsFromQuery);
+}
+
+/**
  * Called by the route when comparisonId or eventIdsFromQuery change.
  * Uses a single "loaded key" to avoid duplicate or infinite loads.
  */

--- a/frontend/src/routes/__tests__/comparison-view.test.ts
+++ b/frontend/src/routes/__tests__/comparison-view.test.ts
@@ -454,4 +454,23 @@ describe('ComparisonView', () => {
     const nameInput = screen.getByPlaceholderText('Enter comparison name');
     expect(nameInput).toHaveValue('Cycling / Garmin Forerunner 945 vs Wahoo Elemnt');
   });
+
+  it('reloads data when page becomes visible again (visibilitychange)', async () => {
+    render(ComparisonView, {
+      props: { params: { id: 'new' }, query: { events: 'evt-1,evt-2' } },
+    });
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: 'Save Comparison' })).toBeInTheDocument();
+    });
+    const getEventCallsBefore = mockGetEvent.mock.calls.length;
+    expect(getEventCallsBefore).toBeGreaterThanOrEqual(2);
+
+    // Simulate tab becoming visible again (e.g. user switched back to this tab)
+    Object.defineProperty(document, 'visibilityState', { value: 'visible', configurable: true });
+    document.dispatchEvent(new Event('visibilitychange'));
+
+    await waitFor(() => {
+      expect(mockGetEvent.mock.calls.length).toBeGreaterThan(getEventCallsBefore);
+    });
+  });
 });

--- a/frontend/src/routes/comparison-view.svelte
+++ b/frontend/src/routes/comparison-view.svelte
@@ -23,7 +23,7 @@
   import { calculateDelta } from '../lib/utils/comparison-chart-data';
   import {
     state as loaderState,
-    load as loaderLoad,
+    reload as loaderReload,
     loadStreams as loaderLoadStreams,
     setSelectedActivities,
     setSelectedStreamTypes,
@@ -100,9 +100,23 @@
   const eventIdsFromQuery = $derived(eventIdsFromQueryState);
   const folderIdForNewComparison = $derived(folderIdFromQueryState);
 
-  // Trigger loader when comparisonId or (for 'new') eventIdsFromQueryState change
+  // Trigger loader when comparisonId or (for 'new') eventIdsFromQueryState change.
+  // Use reload() so we refetch when returning to this page (e.g. after editing event device name).
   $effect(() => {
-    loaderLoad(comparisonId, eventIdsFromQueryState);
+    loaderReload(comparisonId, eventIdsFromQueryState);
+  });
+
+  // Also reload when user returns to this tab (visibility visible) to pick up external edits.
+  $effect(() => {
+    const id = comparisonId;
+    const eventIds = eventIdsFromQueryState;
+    const handler = () => {
+      if (document.visibilityState === 'visible') {
+        loaderReload(id, eventIds);
+      }
+    };
+    document.addEventListener('visibilitychange', handler);
+    return () => document.removeEventListener('visibilitychange', handler);
   });
 
   const EVENT_COLORS = ['#ef4444', '#3b82f6', '#10b981', '#f59e0b', '#a855f7', '#ec4899'];


### PR DESCRIPTION
**Changes:**
 * Add reload() in comparison-loader to force refetch by clearing lastLoadedKey
 * Use reload in comparison-view route effect so returning from event detail refetches data
 * Add visibilitychange listener to refetch when tab becomes visible again
 * Add test for visibility-based refresh (getEvent called again after visibilitychange)