### PR TITLE
Add Power Curve chart to event detail and comparison view

### DIFF
--- a/frontend/src/lib/components/event-detail/PowerCurveChart.svelte
+++ b/frontend/src/lib/components/event-detail/PowerCurveChart.svelte
@@ -1,0 +1,319 @@
+<script lang="ts">
+  import uPlot from 'uplot';
+  import 'uplot/dist/uPlot.min.css';
+  import {
+    formatDurationCompact,
+    getPowerCurveSplits,
+    CHART_HEIGHT,
+    CHART_TEXT_COLOR,
+    CHART_GRID_COLOR,
+    CHART_POWER_COLOR,
+    getSmoothPath,
+  } from '../../utils/chart-utils';
+
+  export interface CurveSeries {
+    activityId: string;
+    activityName: string;
+    color?: string;
+    data: Array<{ duration: number; power: number }>;
+  }
+
+  interface Props {
+    series: CurveSeries[];
+    showToggleButtons?: boolean;
+    selectedActivityIds?: Set<string>;
+    onToggleActivity?: (activityId: string) => void;
+    maxDuration?: number; // Maximum duration in seconds to display on x-axis
+  }
+
+  let {
+    series,
+    showToggleButtons = false,
+    selectedActivityIds,
+    onToggleActivity,
+    maxDuration,
+  }: Props = $props();
+
+  let containerEl: HTMLDivElement | null = $state(null);
+  let chartInstance: uPlot | null = $state(null);
+  let isZoomed = $state(false);
+  const chartRef = { current: null as uPlot | null };
+
+  const smoothPath = getSmoothPath();
+
+  /** Series to display: filter by selectedActivityIds when in comparison mode. */
+  const visibleSeries = $derived.by(() => {
+    if (!series.length) return [];
+    if (showToggleButtons && selectedActivityIds && selectedActivityIds.size > 0) {
+      return series.filter((s) => selectedActivityIds!.has(s.activityId));
+    }
+    return series;
+  });
+
+  /** Union of all duration values across visible series, sorted, filtered to maxDuration. */
+  const sharedX = $derived.by(() => {
+    const xSet = new Set<number>();
+    const limit = maxDuration;
+    for (const s of visibleSeries) {
+      for (const p of s.data) {
+        if (Number.isFinite(p.duration) && p.duration > 0) {
+          if (!limit || p.duration <= limit) xSet.add(p.duration);
+        }
+      }
+    }
+    return Array.from(xSet).sort((a, b) => a - b);
+  });
+
+  /** For a series, get power at a given duration (use nearest point with duration <= x, or first point). */
+  function powerAtDuration(
+    data: Array<{ duration: number; power: number }>,
+    x: number
+  ): number | null {
+    if (!data.length) return null;
+    let best: { duration: number; power: number } | null = null;
+    for (const p of data) {
+      if (p.duration <= x && Number.isFinite(p.power)) {
+        if (!best || p.duration >= best.duration) best = p;
+      }
+    }
+    if (best) return best.power;
+    if (data[0].duration >= x && Number.isFinite(data[0].power)) return data[0].power;
+    return null;
+  }
+
+  const chartData = $derived.by(() => {
+    if (visibleSeries.length === 0 || sharedX.length === 0)
+      return { data: null as uPlot.AlignedData | null, xMin: 0, xMax: 0 };
+
+    const xMin = sharedX[0];
+    // Use maxDuration if provided (activity duration), otherwise use max from data
+    const xMax = maxDuration ?? sharedX[sharedX.length - 1];
+    const yArrays: (number | null)[][] = [];
+
+    for (const s of visibleSeries) {
+      yArrays.push(sharedX.map((x) => powerAtDuration(s.data, x)));
+    }
+
+    const data: uPlot.AlignedData = [sharedX, ...yArrays];
+    return { data, xMin, xMax };
+  });
+
+  function resetZoom() {
+    if (!chartInstance || !chartData.data) return;
+    const { xMin, xMax } = chartData;
+    chartInstance.batch(() => {
+      chartInstance!.setScale('x', { min: xMin, max: xMax });
+    });
+    isZoomed = false;
+  }
+
+  $effect(() => {
+    if (!containerEl || !chartData.data || visibleSeries.length === 0) return;
+
+    const textColor = CHART_TEXT_COLOR;
+    const gridColor = CHART_GRID_COLOR;
+
+    if (chartRef.current) {
+      chartRef.current.destroy();
+      chartRef.current = null;
+    }
+
+    const { data, xMin, xMax } = chartData;
+    const nSeries = visibleSeries.length;
+
+    const uPlotSeries: uPlot.Series[] = [{}];
+    for (let i = 0; i < nSeries; i++) {
+      const s = visibleSeries[i];
+      const color = s.color || CHART_POWER_COLOR;
+      uPlotSeries.push({
+        label: s.activityName,
+        stroke: color,
+        width: 2,
+        paths: smoothPath,
+        fill: (u, seriesIdx) => {
+          const ser = u.series[seriesIdx];
+          const scaleKey = (ser.scale as string) || 'y';
+          const sc = u.scales[scaleKey];
+          if (!sc || sc.min == null || sc.max == null) return color + '40';
+          const top = u.valToPos(sc.max, scaleKey, true);
+          const bottom = u.valToPos(sc.min, scaleKey, true);
+          const ctx = u.ctx;
+          if (!ctx) return color + '40';
+          const grd = ctx.createLinearGradient(0, top, 0, bottom);
+          grd.addColorStop(0, color + '40');
+          grd.addColorStop(1, color + '00');
+          return grd;
+        },
+        value: (_u, raw) => (raw == null ? '' : `${Math.round(raw)} W`),
+      });
+    }
+
+    const opts: uPlot.Options = {
+      width: containerEl.offsetWidth,
+      height: CHART_HEIGHT,
+      series: uPlotSeries,
+      scales: {
+        x: {
+          time: false,
+          distr: 3,
+          log: 10,
+          range: () => [xMin, xMax],
+        },
+        y: { auto: true },
+      },
+      axes: [
+        {
+          stroke: textColor,
+          grid: {
+            stroke: gridColor,
+            width: 1,
+            filter: (_u, splits) => splits,
+          },
+          ticks: {
+            stroke: textColor,
+            filter: (_u, splits) => splits,
+          },
+          filter: (_u, splits) => splits,
+          splits: (_u, _axisIdx, scaleMin, scaleMax) => getPowerCurveSplits(scaleMin, scaleMax),
+          values: (_u, ticks) =>
+            ticks.map((t) => (typeof t === 'number' ? formatDurationCompact(t) : '')),
+          label: 'Duration',
+          labelFont: '13px system-ui',
+          font: '13px system-ui',
+          size: 40,
+          gap: 8,
+          space: 1,
+        },
+        {
+          stroke: textColor,
+          grid: { stroke: gridColor, width: 1 },
+          ticks: { stroke: textColor },
+          values: (_u, ticks) =>
+            ticks.map((t) => (typeof t === 'number' ? `${Math.round(t)}` : '')),
+          label: 'Power (W)',
+          labelFont: '13px system-ui',
+          font: '13px system-ui',
+          size: 36,
+          gap: 5,
+          space: 80,
+          labelGap: 12,
+          labelSize: 42,
+        },
+      ],
+      cursor: {
+        show: true,
+        x: true,
+        y: true,
+        drag: { setScale: true, x: true, y: false },
+        points: { show: true, size: 10, width: 2, stroke: '#ffffff', fill: CHART_POWER_COLOR },
+      },
+      legend: { show: true, live: true },
+      hooks: {
+        setSelect: [
+          (u) => {
+            setTimeout(() => {
+              const xScale = u.scales.x;
+              if (!xScale || xScale.min == null || xScale.max == null) return;
+              const tol = (chartData.xMax - chartData.xMin) * 0.01;
+              isZoomed =
+                Math.abs(xScale.min - chartData.xMin) > tol ||
+                Math.abs(xScale.max - chartData.xMax) > tol;
+            }, 0);
+          },
+        ],
+      },
+    };
+
+    const u = new uPlot(opts, data, containerEl);
+    chartRef.current = u;
+    chartInstance = u;
+
+    const ro = new ResizeObserver(() => {
+      if (chartRef.current && containerEl) {
+        chartRef.current.setSize({ width: containerEl.offsetWidth, height: CHART_HEIGHT });
+      }
+    });
+    ro.observe(containerEl);
+
+    return () => {
+      ro.disconnect();
+      if (chartRef.current) {
+        chartRef.current.destroy();
+        chartRef.current = null;
+      }
+      chartInstance = null;
+    };
+  });
+</script>
+
+<div class="w-full animate-fade-in">
+  {#if series.length === 0}
+    <div class="flex h-96 items-center justify-center rounded-lg border border-border bg-card">
+      <p class="text-sm text-text-secondary">No power curve data</p>
+    </div>
+  {:else if visibleSeries.length === 0}
+    <div class="flex h-96 items-center justify-center rounded-lg border border-border bg-card">
+      <p class="text-sm text-text-secondary">Select activities above to view power curves</p>
+    </div>
+  {:else if !chartData.data}
+    <div class="flex h-96 items-center justify-center rounded-lg border border-border bg-card">
+      <p class="text-sm text-text-secondary">No valid power curve points</p>
+    </div>
+  {:else}
+    <div class="relative pb-6">
+      {#if showToggleButtons && series.length > 0 && onToggleActivity}
+        <div class="mb-3 flex flex-wrap gap-2">
+          {#each series as s (s.activityId)}
+            {@const isSelected = !selectedActivityIds || selectedActivityIds.has(s.activityId)}
+            <button
+              type="button"
+              class="flex items-center gap-2 rounded-full border px-3 py-1.5 text-sm transition-colors {isSelected
+                ? 'text-text-primary'
+                : 'border-border bg-transparent text-text-muted hover:bg-card-hover'}"
+              style={isSelected ? `background-color: ${s.color}26; border-color: ${s.color}66` : ''}
+              onclick={() => onToggleActivity(s.activityId)}
+            >
+              <span
+                class="h-2 w-2 rounded-full {isSelected ? '' : 'opacity-40'}"
+                style="background-color: {s.color};"
+              ></span>
+              <span>{s.activityName}</span>
+            </button>
+          {/each}
+        </div>
+      {/if}
+      <button
+        type="button"
+        class="absolute right-2 top-2 z-10 rounded border border-border bg-card px-2 py-1 text-xs text-text-primary opacity-75 transition-opacity hover:opacity-100"
+        onclick={resetZoom}
+        style="display: {isZoomed ? 'block' : 'none'};"
+      >
+        Reset Zoom
+      </button>
+      <div class="h-96 w-full" bind:this={containerEl}></div>
+    </div>
+  {/if}
+</div>
+
+<style>
+  @keyframes fade-in {
+    from {
+      opacity: 0;
+      transform: translateY(4px);
+    }
+    to {
+      opacity: 1;
+      transform: translateY(0);
+    }
+  }
+  .animate-fade-in {
+    animation: fade-in 0.3s ease-out;
+  }
+  :global(.uplot .u-legend) {
+    color: var(--color-text-secondary);
+    margin-bottom: 0.75rem;
+  }
+  :global(.uplot .u-legend tbody tr:first-child) {
+    display: none;
+  }
+</style>

--- a/frontend/src/lib/components/event-detail/__tests__/PowerCurveChart.test.ts
+++ b/frontend/src/lib/components/event-detail/__tests__/PowerCurveChart.test.ts
@@ -1,0 +1,113 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/svelte';
+import PowerCurveChart from '../PowerCurveChart.svelte';
+
+vi.mock('uplot', () => {
+  const mockInstance = {
+    destroy: vi.fn(),
+    batch: vi.fn((fn: () => void) => {
+      if (fn) fn();
+    }),
+    setSize: vi.fn(),
+    setScale: vi.fn(),
+  };
+  const Mock = vi.fn(function (this: unknown) {
+    return mockInstance;
+  });
+  (Mock as unknown as { paths: Record<string, () => () => void> }).paths = {
+    spline: () => () => {},
+    linear: () => () => {},
+  };
+  return { default: Mock };
+});
+
+const singleSeries = [
+  {
+    activityId: 'act-1',
+    activityName: 'Power',
+    color: '#a855f7',
+    data: [
+      { duration: 1, power: 417 },
+      { duration: 5, power: 411 },
+      { duration: 60, power: 362 },
+      { duration: 300, power: 335 },
+    ],
+  },
+];
+
+const multiSeries = [
+  { ...singleSeries[0], activityId: 'act-1', activityName: 'Activity 1' },
+  {
+    activityId: 'act-2',
+    activityName: 'Activity 2',
+    color: '#3b82f6',
+    data: [
+      { duration: 1, power: 400 },
+      { duration: 60, power: 350 },
+      { duration: 300, power: 320 },
+    ],
+  },
+];
+
+describe('PowerCurveChart', () => {
+  it('shows no power curve data message when series is empty', () => {
+    render(PowerCurveChart, { props: { series: [] } });
+    expect(screen.getByText('No power curve data')).toBeInTheDocument();
+  });
+
+  it('renders chart when single series is provided', () => {
+    render(PowerCurveChart, { props: { series: singleSeries } });
+    expect(document.querySelector('.h-96')).toBeInTheDocument();
+    expect(screen.queryByText('No power curve data')).not.toBeInTheDocument();
+  });
+
+  it('renders chart when multiple series are provided', () => {
+    render(PowerCurveChart, { props: { series: multiSeries } });
+    expect(document.querySelector('.h-96')).toBeInTheDocument();
+  });
+
+  it('shows toggle buttons when showToggleButtons is true', () => {
+    render(PowerCurveChart, {
+      props: {
+        series: multiSeries,
+        showToggleButtons: true,
+        selectedActivityIds: new Set(['act-1', 'act-2']),
+        onToggleActivity: vi.fn(),
+      },
+    });
+    expect(screen.getByRole('button', { name: 'Activity 1' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Activity 2' })).toBeInTheDocument();
+  });
+
+  it('calls onToggleActivity when toggle button is clicked', async () => {
+    const onToggleActivity = vi.fn();
+    render(PowerCurveChart, {
+      props: {
+        series: multiSeries,
+        showToggleButtons: true,
+        selectedActivityIds: new Set(['act-1', 'act-2']),
+        onToggleActivity,
+      },
+    });
+    await fireEvent.click(screen.getByRole('button', { name: 'Activity 1' }));
+    expect(onToggleActivity).toHaveBeenCalledWith('act-1');
+  });
+
+  it('shows "Select activities above" when showToggleButtons true and no visible series', () => {
+    render(PowerCurveChart, {
+      props: {
+        series: multiSeries,
+        showToggleButtons: true,
+        selectedActivityIds: new Set(['other-id']),
+        onToggleActivity: vi.fn(),
+      },
+    });
+    expect(screen.getByText('Select activities above to view power curves')).toBeInTheDocument();
+  });
+
+  it('shows chart container when series is provided', () => {
+    render(PowerCurveChart, { props: { series: singleSeries } });
+    const chartContainer = document.querySelector('.h-96');
+    expect(chartContainer).toBeInTheDocument();
+  });
+});

--- a/frontend/src/lib/utils/__tests__/chart-utils.test.ts
+++ b/frontend/src/lib/utils/__tests__/chart-utils.test.ts
@@ -13,7 +13,11 @@ import {
   formatElapsedTime,
   formatWallClockTime,
   formatYValue,
+  formatDurationCompact,
+  CHART_POWER_COLOR,
+  getPowerCurveSplits,
   getSmoothPath,
+  POWER_CURVE_SPLITS,
 } from '../chart-utils';
 
 describe('formatElapsedTime', () => {
@@ -67,9 +71,50 @@ describe('formatYValue', () => {
   });
 });
 
+describe('getPowerCurveSplits', () => {
+  it('returns only breakpoints within the given range', () => {
+    expect(getPowerCurveSplits(10, 120)).toEqual([10, 15, 20, 30, 60, 120]);
+    expect(getPowerCurveSplits(1, 30)).toEqual([1, 2, 5, 10, 15, 20, 30]);
+  });
+  it('returns the full array when range covers all breakpoints', () => {
+    expect(getPowerCurveSplits(1, 7200)).toEqual(POWER_CURVE_SPLITS);
+    expect(getPowerCurveSplits(0, 10000)).toEqual(POWER_CURVE_SPLITS);
+  });
+  it('returns empty when range is outside all breakpoints', () => {
+    expect(getPowerCurveSplits(0.5, 0.9)).toEqual([]);
+    expect(getPowerCurveSplits(10000, 20000)).toEqual([]);
+  });
+});
+
 describe('getSmoothPath', () => {
   it('returns linear path builder when spline is missing (fallback)', () => {
     const pathBuilder = getSmoothPath();
     expect(typeof pathBuilder).toBe('function');
+  });
+});
+
+describe('formatDurationCompact', () => {
+  it('formats seconds with s suffix', () => {
+    expect(formatDurationCompact(1)).toBe('1s');
+    expect(formatDurationCompact(5)).toBe('5s');
+    expect(formatDurationCompact(59)).toBe('59s');
+  });
+  it('formats minutes with m suffix', () => {
+    expect(formatDurationCompact(60)).toBe('1m');
+    expect(formatDurationCompact(300)).toBe('5m');
+    expect(formatDurationCompact(3599)).toBe('60m');
+  });
+  it('formats hours with h suffix', () => {
+    expect(formatDurationCompact(3600)).toBe('1.0h');
+    expect(formatDurationCompact(7200)).toBe('2.0h');
+  });
+  it('clamps negative to 0s', () => {
+    expect(formatDurationCompact(-10)).toBe('0s');
+  });
+});
+
+describe('CHART_POWER_COLOR', () => {
+  it('is a hex color string', () => {
+    expect(CHART_POWER_COLOR).toMatch(/^#[0-9a-fA-F]{6}$/);
   });
 });

--- a/frontend/src/lib/utils/__tests__/stat-formatting.test.ts
+++ b/frontend/src/lib/utils/__tests__/stat-formatting.test.ts
@@ -145,6 +145,13 @@ describe('formatDuration', () => {
 });
 
 describe('formatStatValue', () => {
+  it('returns empty string for PowerCurve (displayed as chart instead)', () => {
+    const powerCurveData = [
+      { duration: 1, power: 417 },
+      { duration: 60, power: 362 },
+    ] as unknown as Parameters<typeof formatStatValue>[0];
+    expect(formatStatValue(powerCurveData, 'PowerCurve')).toBe('');
+  });
   it('returns empty string for null', () => {
     expect(formatStatValue(null, 'Duration')).toBe('');
   });

--- a/frontend/src/lib/utils/chart-utils.ts
+++ b/frontend/src/lib/utils/chart-utils.ts
@@ -9,6 +9,35 @@ export const CHART_TEXT_COLOR = '#d1d5db';
 /** Grid line color for chart axes. */
 export const CHART_GRID_COLOR = 'rgba(255,255,255,0.12)';
 
+/** Default color for power curves (matches Power stream in stream-config). */
+export const CHART_POWER_COLOR = '#a855f7';
+
+/**
+ * Human-meaningful duration breakpoints (seconds) for Power Curve x-axis gridlines.
+ * Labels: 1s, 2s, 5s, 10s, 15s, 20s, 30s, 1m, 2m, 5m, 10m, 20m, 30m, 1h, 1.5h, 2h.
+ */
+export const POWER_CURVE_SPLITS = [
+  1, 2, 5, 10, 15, 20, 30, 60, 120, 300, 600, 1200, 1800, 3600, 5400, 7200,
+];
+
+/**
+ * Returns Power Curve x-axis splits (gridline positions) within the visible scale range.
+ */
+export function getPowerCurveSplits(scaleMin: number, scaleMax: number): number[] {
+  return POWER_CURVE_SPLITS.filter((v) => v >= scaleMin && v <= scaleMax);
+}
+
+/**
+ * Format duration in seconds for PowerCurve X-axis labels (e.g. "1s", "5m", "1h").
+ * Used on logarithmic duration axis.
+ */
+export function formatDurationCompact(seconds: number): string {
+  const s = Math.max(0, Math.round(seconds));
+  if (s < 60) return `${s}s`;
+  if (s < 3600) return `${Math.round(s / 60)}m`;
+  return `${(s / 3600).toFixed(1)}h`;
+}
+
 /**
  * Format milliseconds since epoch or elapsed ms as H:MM:SS or M:SS.
  * Input is treated as elapsed time (e.g. relative to activity start).

--- a/frontend/src/lib/utils/stat-categories.ts
+++ b/frontend/src/lib/utils/stat-categories.ts
@@ -131,6 +131,7 @@ export function getGroupedDeduplicatedStats(entries: StatEntry[]): StatsByCatego
   });
 
   for (const entry of sorted) {
+    if (entry.statType === 'PowerCurve') continue;
     const parsed = parseStat(entry.statType);
     if (!getStatIcon(entry.statType)) continue;
     const key = metricAggregationKeyNormalized(parsed);

--- a/frontend/src/lib/utils/stat-formatting.ts
+++ b/frontend/src/lib/utils/stat-formatting.ts
@@ -130,6 +130,9 @@ export function formatStatValue(
   statType?: string
 ): string {
   if (value == null) return '';
+  if (statType === 'PowerCurve') {
+    return '';
+  }
   if (statType) {
     const n = typeof value === 'string' ? Number(value) : value;
     if (typeof n === 'number' && Number.isFinite(n)) {

--- a/frontend/src/routes/comparison-view.svelte
+++ b/frontend/src/routes/comparison-view.svelte
@@ -43,6 +43,7 @@
   import ComparisonStatsTable from '../lib/components/comparison/ComparisonStatsTable.svelte';
   import StreamAnalysisSection from '../lib/components/comparison/StreamAnalysisSection.svelte';
   import RouteMap from '../lib/components/RouteMap.svelte';
+  import PowerCurveChart from '../lib/components/event-detail/PowerCurveChart.svelte';
   import { foldersState, buildFolderHash } from '../lib/stores/folders.svelte';
 
   const comparisonId = $derived(params?.id ?? '');
@@ -287,6 +288,57 @@
       else next.add(type);
       return next;
     });
+  }
+
+  const powerCurveSeries = $derived.by(() => {
+    const result: Array<{
+      activityId: string;
+      activityName: string;
+      color: string;
+      data: Array<{ duration: number; power: number }>;
+    }> = [];
+    events.forEach((eventDetail, index) => {
+      const eventId = eventDetail.event.id;
+      const activityId = selectedActivities[eventId];
+      if (!activityId) return;
+      const activity = eventDetail.activities.find((a) => a.id === activityId);
+      if (!activity) return;
+      const pc = activity.stats?.['PowerCurve'];
+      if (!Array.isArray(pc) || pc.length === 0) return;
+      result.push({
+        activityId,
+        activityName:
+          getActivityDeviceName(activity) || eventDetail.event.name || `Activity ${index + 1}`,
+        color: EVENT_COLORS[index % EVENT_COLORS.length],
+        data: pc as unknown as Array<{ duration: number; power: number }>,
+      });
+    });
+    return result;
+  });
+
+  const powerCurveMaxDuration = $derived.by(() => {
+    let maxDuration = 0;
+    for (const eventDetail of events) {
+      const eventId = eventDetail.event.id;
+      const activityId = selectedActivities[eventId];
+      if (!activityId) continue;
+      const activity = eventDetail.activities.find((a) => a.id === activityId);
+      if (!activity?.startDate || !activity?.endDate) continue;
+      const duration = Math.round((activity.endDate - activity.startDate) / 1000);
+      if (duration > maxDuration) maxDuration = duration;
+    }
+    return maxDuration > 0 ? maxDuration : undefined;
+  });
+
+  let selectedPowerCurveIds = $state<Set<string>>(new Set());
+
+  function togglePowerCurveActivity(activityId: string) {
+    selectedPowerCurveIds = (() => {
+      const next = new Set(selectedPowerCurveIds);
+      if (next.has(activityId)) next.delete(activityId);
+      else next.add(activityId);
+      return next;
+    })();
   }
 
   function toggleHiddenStat(statType: string) {
@@ -860,6 +912,25 @@
         </div>
       {/if}
     </div>
+
+    <!-- Power Curve Section -->
+    {#if powerCurveSeries.length > 0}
+      <div
+        class="mb-6 overflow-hidden rounded-xl border border-border bg-card p-6 shadow-sm backdrop-blur-lg"
+      >
+        <h3 class="mb-4 flex items-center gap-2 text-base font-semibold text-text-primary">
+          <span class="material-icons text-xl text-text-muted">bolt</span>
+          Power Curve
+        </h3>
+        <PowerCurveChart
+          series={powerCurveSeries}
+          showToggleButtons={true}
+          selectedActivityIds={selectedPowerCurveIds}
+          onToggleActivity={togglePowerCurveActivity}
+          maxDuration={powerCurveMaxDuration}
+        />
+      </div>
+    {/if}
 
     <!-- Stream Analysis Section -->
     <StreamAnalysisSection

--- a/frontend/src/routes/event-detail.svelte
+++ b/frontend/src/routes/event-detail.svelte
@@ -28,6 +28,7 @@
   import StatCard from '../lib/components/StatCard.svelte';
   import EventDetailMoreStats from '../lib/components/event-detail/EventDetailMoreStats.svelte';
   import EventDetailStreamCharts from '../lib/components/event-detail/EventDetailStreamCharts.svelte';
+  import PowerCurveChart from '../lib/components/event-detail/PowerCurveChart.svelte';
   import { buildFolderHash } from '../lib/stores/folders.svelte';
 
   const id = $derived(params?.id ?? '');
@@ -305,6 +306,25 @@
 
   const locationAvailable = $derived(hasLocationStreams(streams));
 
+  const powerCurveSeries = $derived.by(() => {
+    const pc = selectedActivity?.stats?.['PowerCurve'] ?? event?.stats?.['PowerCurve'];
+    if (!Array.isArray(pc) || pc.length === 0) return [];
+    const curve = pc as unknown as Array<{ duration: number; power: number }>;
+    return [
+      {
+        activityId: selectedActivity?.id ?? event?.id ?? '',
+        activityName: 'Power',
+        data: curve,
+      },
+    ];
+  });
+
+  const powerCurveMaxDuration = $derived.by(() => {
+    const activity = selectedActivity;
+    if (!activity?.startDate || !activity?.endDate) return undefined;
+    return Math.round((activity.endDate - activity.startDate) / 1000);
+  });
+
   // Filter to only selected streams (order: Heart Rate first, then rest)
   const visibleStreams = $derived(
     chartableStreamsOrdered.filter((s) => selectedStreamTypes.has(s.type))
@@ -577,6 +597,18 @@
     {#if locationAvailable && !streamsLoading}
       <div class="mt-6 overflow-hidden rounded-xl border border-border shadow-sm">
         <RouteMap {streams} />
+      </div>
+    {/if}
+
+    {#if powerCurveSeries.length > 0}
+      <div
+        class="mt-6 overflow-hidden rounded-xl border border-border bg-card p-6 shadow-sm backdrop-blur-lg"
+      >
+        <h3 class="mb-4 flex items-center gap-2 text-base font-semibold text-text-primary">
+          <span class="material-icons text-xl text-text-muted">bolt</span>
+          Power Curve
+        </h3>
+        <PowerCurveChart series={powerCurveSeries} maxDuration={powerCurveMaxDuration} />
       </div>
     {/if}
 


### PR DESCRIPTION
**Changes:**
 * Add PowerCurveChart.svelte (uPlot) and tests
 * Add chart-utils: CHART_POWER_COLOR, POWER_CURVE_SPLITS, getPowerCurveSplits, formatDurationCompact
 * Exclude PowerCurve from stat categories and stat value formatting (no scalar display)
 * Integrate PowerCurveChart in event-detail and comparison-view with series/toggle support
 * Update chart-utils and stat-formatting tests