### PR TITLE
Power curve PNG export and remove bolt from heading

### DIFF
--- a/frontend/src/lib/components/event-detail/PowerCurveChart.svelte
+++ b/frontend/src/lib/components/event-detail/PowerCurveChart.svelte
@@ -287,6 +287,7 @@
         class="absolute right-2 top-2 z-10 rounded border border-border bg-card px-2 py-1 text-xs text-text-primary opacity-75 transition-opacity hover:opacity-100"
         onclick={resetZoom}
         style="display: {isZoomed ? 'block' : 'none'};"
+        data-export-exclude
       >
         Reset Zoom
       </button>

--- a/frontend/src/routes/comparison-view.svelte
+++ b/frontend/src/routes/comparison-view.svelte
@@ -44,9 +44,13 @@
   import StreamAnalysisSection from '../lib/components/comparison/StreamAnalysisSection.svelte';
   import RouteMap from '../lib/components/RouteMap.svelte';
   import PowerCurveChart from '../lib/components/event-detail/PowerCurveChart.svelte';
+  import ExportButton from '../lib/components/ExportButton.svelte';
+  import { exportAsPng } from '../lib/utils/export-image';
   import { foldersState, buildFolderHash } from '../lib/stores/folders.svelte';
 
   const comparisonId = $derived(params?.id ?? '');
+
+  let powerCurveSectionEl = $state<HTMLElement | null>(null);
 
   const currentLocation = $derived($location);
 
@@ -916,12 +920,18 @@
     <!-- Power Curve Section -->
     {#if powerCurveSeries.length > 0}
       <div
+        bind:this={powerCurveSectionEl}
         class="mb-6 overflow-hidden rounded-xl border border-border bg-card p-6 shadow-sm backdrop-blur-lg"
       >
-        <h3 class="mb-4 flex items-center gap-2 text-base font-semibold text-text-primary">
-          <span class="material-icons text-xl text-text-muted">bolt</span>
-          Power Curve
-        </h3>
+        <div class="mb-4 flex items-center justify-between">
+          <h3 class="text-base font-semibold text-text-primary">Power Curve</h3>
+          {#if powerCurveSectionEl}
+            <ExportButton
+              onExport={() => exportAsPng(powerCurveSectionEl!, 'power-curve-comparison')}
+              title="Export chart as PNG"
+            />
+          {/if}
+        </div>
         <PowerCurveChart
           series={powerCurveSeries}
           showToggleButtons={true}

--- a/frontend/src/routes/event-detail.svelte
+++ b/frontend/src/routes/event-detail.svelte
@@ -29,11 +29,14 @@
   import EventDetailMoreStats from '../lib/components/event-detail/EventDetailMoreStats.svelte';
   import EventDetailStreamCharts from '../lib/components/event-detail/EventDetailStreamCharts.svelte';
   import PowerCurveChart from '../lib/components/event-detail/PowerCurveChart.svelte';
+  import ExportButton from '../lib/components/ExportButton.svelte';
+  import { exportAsPng } from '../lib/utils/export-image';
   import { buildFolderHash } from '../lib/stores/folders.svelte';
 
   const id = $derived(params?.id ?? '');
 
   let backFolderId = $state<string | null>(null);
+  let powerCurveSectionEl = $state<HTMLElement | null>(null);
 
   $effect(() => {
     if (query?.back?.trim()) {
@@ -602,12 +605,18 @@
 
     {#if powerCurveSeries.length > 0}
       <div
+        bind:this={powerCurveSectionEl}
         class="mt-6 overflow-hidden rounded-xl border border-border bg-card p-6 shadow-sm backdrop-blur-lg"
       >
-        <h3 class="mb-4 flex items-center gap-2 text-base font-semibold text-text-primary">
-          <span class="material-icons text-xl text-text-muted">bolt</span>
-          Power Curve
-        </h3>
+        <div class="mb-4 flex items-center justify-between">
+          <h3 class="text-base font-semibold text-text-primary">Power Curve</h3>
+          {#if powerCurveSectionEl}
+            <ExportButton
+              onExport={() => exportAsPng(powerCurveSectionEl!, 'power-curve')}
+              title="Export chart as PNG"
+            />
+          {/if}
+        </div>
         <PowerCurveChart series={powerCurveSeries} maxDuration={powerCurveMaxDuration} />
       </div>
     {/if}


### PR DESCRIPTION
**Changes:**
 * Add PNG export for Power Curve on event detail and comparison view
 * Exclude Reset Zoom button from power curve export capture
 * Remove bolt icon from Power Curve headings (fix stray "bolt" text)