### PR TITLE
Drop event_id from streams table

### DIFF
--- a/backend/README.md
+++ b/backend/README.md
@@ -47,5 +47,5 @@ See `sql/schema.sql`. Key indexes:
 - **`user_identities`**: unique (provider, provider_user_id); index on `user_id`.
 - **`events`**: `start_date`; `user_id`; composite (user_id, start_date).
 - **`activities`**: indexes on `event_id`, `type`, `device_name`, `start_date`.
-- **`streams`**: (activity_id), (event_id), (type); stream data stored as compressed JSON in `data` column.
+- **`streams`**: (activity_id), (type); stream data stored as compressed JSON in `data` column.
 - **`comparisons`**: `created_at`; `user_id`; composite (user_id, created_at).

--- a/backend/sql/migrations/004_drop_streams_event_id.sql
+++ b/backend/sql/migrations/004_drop_streams_event_id.sql
@@ -1,0 +1,5 @@
+-- Drop denormalized event_id from streams; ownership scoping via activities.event_id.
+ALTER TABLE streams
+  DROP FOREIGN KEY fk_streams_event,
+  DROP INDEX idx_event_id,
+  DROP COLUMN event_id;

--- a/backend/sql/schema.sql
+++ b/backend/sql/schema.sql
@@ -116,15 +116,12 @@ COLLATE = utf8mb4_unicode_ci;
 CREATE TABLE IF NOT EXISTS streams (
   id VARCHAR(128) PRIMARY KEY,
   activity_id VARCHAR(36) NOT NULL,
-  event_id VARCHAR(36) NOT NULL,
   type VARCHAR(128) NOT NULL,
   data JSON COMPRESSED NOT NULL DEFAULT ('[]'),
   INDEX idx_activity_id (activity_id),
-  INDEX idx_event_id (event_id),
   INDEX idx_type (type),
   UNIQUE KEY unique_activity_stream_type (activity_id, type),
-  CONSTRAINT fk_streams_activity FOREIGN KEY (activity_id) REFERENCES activities (id) ON DELETE CASCADE,
-  CONSTRAINT fk_streams_event FOREIGN KEY (event_id) REFERENCES events (id) ON DELETE CASCADE
+  CONSTRAINT fk_streams_activity FOREIGN KEY (activity_id) REFERENCES activities (id) ON DELETE CASCADE
 )
 DEFAULT CHARSET = utf8mb4
 COLLATE = utf8mb4_unicode_ci;

--- a/backend/src/repositories/stream-repository.js
+++ b/backend/src/repositories/stream-repository.js
@@ -1,9 +1,9 @@
 const { runQuery, placeholders } = require('./query-helper');
 
-async function insertStream(streamId, activityId, eventId, type, data, opts = {}) {
+async function insertStream(streamId, activityId, type, data, opts = {}) {
   await runQuery(
-    'INSERT INTO streams (id, activity_id, event_id, type, data) VALUES (?, ?, ?, ?, ?) ON DUPLICATE KEY UPDATE data = VALUES(data)',
-    [streamId, activityId, eventId, type, JSON.stringify(data)],
+    'INSERT INTO streams (id, activity_id, type, data) VALUES (?, ?, ?, ?) ON DUPLICATE KEY UPDATE data = VALUES(data)',
+    [streamId, activityId, type, JSON.stringify(data)],
     opts
   );
 }
@@ -11,9 +11,10 @@ async function insertStream(streamId, activityId, eventId, type, data, opts = {}
 async function findAllByActivityIds(activityIds, opts = {}) {
   if (!activityIds.length) return [];
   if (!opts.userId) throw new Error('findAllByActivityIds requires opts.userId');
-  const sql = `SELECT s.id, s.activity_id, s.event_id, s.type, s.data
+  const sql = `SELECT s.id, s.activity_id, s.type, s.data
      FROM streams s
-     JOIN events e ON e.id = s.event_id AND e.user_id = ?
+     JOIN activities a ON a.id = s.activity_id
+     JOIN events e ON e.id = a.event_id AND e.user_id = ?
      WHERE s.activity_id IN (${placeholders(activityIds.length)})`;
   const rows = await runQuery(sql, [opts.userId, ...activityIds], opts);
   return Array.isArray(rows) ? rows : [];
@@ -22,8 +23,8 @@ async function findAllByActivityIds(activityIds, opts = {}) {
 async function findByActivityAndEvent(activityId, eventId, types, opts = {}) {
   if (!opts.userId) throw new Error('findByActivityAndEvent requires opts.userId');
   let sql =
-    'SELECT s.id, s.type, s.data FROM streams s JOIN events e ON e.id = s.event_id WHERE s.activity_id = ? AND s.event_id = ? AND e.user_id = ?';
-  const params = [activityId, eventId, opts.userId];
+    'SELECT s.id, s.type, s.data FROM streams s JOIN activities a ON a.id = s.activity_id JOIN events e ON e.id = a.event_id AND e.user_id = ? WHERE s.activity_id = ? AND a.event_id = ?';
+  const params = [opts.userId, activityId, eventId];
   if (types && types.length > 0) {
     sql += ` AND s.type IN (${placeholders(types.length)})`;
     params.push(...types);

--- a/backend/src/services/event-upload-service.js
+++ b/backend/src/services/event-upload-service.js
@@ -121,7 +121,7 @@ async function processUpload(fileBuffer, extension, originalFilename, opts = {})
             time: dp.time,
             value: dp.value,
           }));
-          await streamRepository.insertStream(streamId, aid, eventId, streamInfo.type, data, tOpts);
+          await streamRepository.insertStream(streamId, aid, streamInfo.type, data, tOpts);
         }
       }
     }

--- a/backend/test/unit/repositories/activity-repository.test.js
+++ b/backend/test/unit/repositories/activity-repository.test.js
@@ -99,6 +99,20 @@ describe('activity-repository', () => {
       const result = await findByIdAndEventId('a1', 'e1', { db, userId: 'u1' });
       strictEqual(result.id, 'a1');
     });
+
+    it('binds params in SQL order (activityId, eventId, userId)', async () => {
+      const queries = [];
+      const db = {
+        query: async (sql, params) => {
+          queries.push({ sql, params });
+          return [{ id: 'a1', event_id: 'e1' }];
+        },
+      };
+      await findByIdAndEventId('a1', 'e1', { db, userId: 'u1' });
+      strictEqual(queries[0].params[0], 'a1', 'first param is activityId');
+      strictEqual(queries[0].params[1], 'e1', 'second param is eventId');
+      strictEqual(queries[0].params[2], 'u1', 'third param is userId');
+    });
   });
 
   describe('findManyByIds', () => {

--- a/backend/test/unit/repositories/event-repository.test.js
+++ b/backend/test/unit/repositories/event-repository.test.js
@@ -192,6 +192,19 @@ describe('event-repository', () => {
       const result = await getStatsByEventId('e1', { db, userId: 'u1' });
       strictEqual(result.length, 1);
     });
+
+    it('binds params in SQL order (eventId, userId)', async () => {
+      const queries = [];
+      const db = {
+        query: async (sql, params) => {
+          queries.push({ sql, params });
+          return [{ stat_type: 'Distance', value: 5000 }];
+        },
+      };
+      await getStatsByEventId('e1', { db, userId: 'u1' });
+      strictEqual(queries[0].params[0], 'e1', 'first param is eventId');
+      strictEqual(queries[0].params[1], 'u1', 'second param is userId');
+    });
   });
 
   describe('updateFolderId', () => {

--- a/backend/test/unit/repositories/stream-repository.test.js
+++ b/backend/test/unit/repositories/stream-repository.test.js
@@ -16,12 +16,13 @@ describe('stream-repository', () => {
         return { affectedRows: 1 };
       });
       const data = [{ time: 1000, value: 120 }];
-      await insertStream('s1', 'a1', 'e1', 'Heart Rate', data, { db });
+      await insertStream('s1', 'a1', 'Heart Rate', data, { db });
       ok(queries[0].sql.includes('INSERT INTO streams'));
       ok(queries[0].sql.includes('ON DUPLICATE KEY'));
       ok(queries[0].sql.includes('data'));
+      ok(!queries[0].sql.includes('event_id'));
       strictEqual(queries[0].params[0], 's1');
-      strictEqual(queries[0].params[4], JSON.stringify(data));
+      strictEqual(queries[0].params[3], JSON.stringify(data));
     });
   });
 
@@ -43,10 +44,11 @@ describe('stream-repository', () => {
       const db = {
         query: async (sql, params) => {
           queries.push({ sql, params });
-          return [{ id: 's1', activity_id: 'a1', event_id: 'e1', type: 'HR', data: '[]' }];
+          return [{ id: 's1', activity_id: 'a1', type: 'HR', data: '[]' }];
         },
       };
       const result = await findAllByActivityIds(['a1'], { db, userId: 'u1' });
+      ok(queries[0].sql.includes('JOIN activities'));
       ok(queries[0].sql.includes('JOIN events'));
       ok(queries[0].sql.includes('s.data'));
       ok(!queries[0].sql.includes('created_at'));
@@ -71,8 +73,12 @@ describe('stream-repository', () => {
         },
       };
       const result = await findByActivityAndEvent('a1', 'e1', null, { db, userId: 'u1' });
+      ok(queries[0].sql.includes('JOIN activities'));
       ok(queries[0].sql.includes('s.data'));
       ok(!queries[0].sql.includes('s.type IN'));
+      strictEqual(queries[0].params[0], 'u1', 'first param is userId');
+      strictEqual(queries[0].params[1], 'a1', 'second param is activityId');
+      strictEqual(queries[0].params[2], 'e1', 'third param is eventId');
       strictEqual(result.length, 1);
     });
 
@@ -86,7 +92,11 @@ describe('stream-repository', () => {
       };
       await findByActivityAndEvent('a1', 'e1', ['HR', 'Distance'], { db, userId: 'u1' });
       ok(queries[0].sql.includes('s.type IN'));
-      ok(queries[0].params.includes('HR'));
+      strictEqual(queries[0].params[0], 'u1', 'first param is userId');
+      strictEqual(queries[0].params[1], 'a1', 'second param is activityId');
+      strictEqual(queries[0].params[2], 'e1', 'third param is eventId');
+      strictEqual(queries[0].params[3], 'HR');
+      strictEqual(queries[0].params[4], 'Distance');
     });
   });
 });

--- a/backend/test/unit/services/account-service.test.js
+++ b/backend/test/unit/services/account-service.test.js
@@ -125,7 +125,6 @@ describe('account-service', () => {
             {
               id: 's1',
               activity_id: 'a1',
-              event_id: 'e1',
               type: 'heartrate',
               data: '[]',
             },
@@ -199,7 +198,6 @@ describe('account-service', () => {
             {
               id: 's1',
               activity_id: 'a1',
-              event_id: 'e1',
               type: 'hr',
               data: '[{"time":100,"value":72}]',
             },
@@ -267,7 +265,6 @@ describe('account-service', () => {
             {
               id: 's1',
               activity_id: 'a1',
-              event_id: 'e1',
               type: 'hr',
               data: '[{"time":100,"value":72}]',
             },

--- a/backend/test/unit/services/event-upload-service.test.js
+++ b/backend/test/unit/services/event-upload-service.test.js
@@ -137,7 +137,7 @@ describe('event-upload-service processUpload', () => {
     try {
       await processUpload(Buffer.from('x'), 'tcx', 'test.tcx', { db, userId: 'u1' });
       strictEqual(streamInserts.length, 1, 'only the valid stream (Heart Rate) should be inserted');
-      strictEqual(streamInserts[0].params[3], 'Heart Rate');
+      strictEqual(streamInserts[0].params[2], 'Heart Rate');
     } finally {
       FileParser.parseFile.mock.restore();
     }

--- a/backend/test/unit/services/stream-service.test.js
+++ b/backend/test/unit/services/stream-service.test.js
@@ -9,6 +9,23 @@ describe('getStreamsForActivity', () => {
     deepStrictEqual(result, []);
   });
 
+  it('passes userId, activityId, eventId to repository in correct order', async () => {
+    let capturedParams;
+    const db = {
+      query: async (sql, params) => {
+        if (sql.includes('FROM streams')) {
+          capturedParams = params;
+          return [];
+        }
+        return [];
+      },
+    };
+    await getStreamsForActivity('evt-1', 'act-1', {}, { db, userId: 'user-1' });
+    strictEqual(capturedParams[0], 'user-1', 'first param is userId');
+    strictEqual(capturedParams[1], 'act-1', 'second param is activityId');
+    strictEqual(capturedParams[2], 'evt-1', 'third param is eventId');
+  });
+
   it('returns streams with data from packed data column', async () => {
     const db = {
       query: async (sql, params) => {

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -215,7 +215,6 @@ erDiagram
     STREAMS {
         varchar128 id PK
         varchar36 activity_id FK
-        varchar36 event_id FK
         varchar type
         json data
     }


### PR DESCRIPTION
**Changes:**
 * Add migration 004_drop_streams_event_id.sql (drop FK, index, column)
 * Update stream-repository: remove eventId from insertStream, join through activities in findAllByActivityIds and findByActivityAndEvent
 * Update event-upload-service to stop passing eventId to insertStream
 * Update schema.sql reference snapshot and docs (ARCHITECTURE.md, backend/README.md)
 * Update unit tests (stream-repository, account-service, event-upload-service)
