### PR TITLE
Add Docker layer caching to publish workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -43,6 +43,9 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
       - name: Extract metadata
         id: meta
         uses: docker/metadata-action@v6
@@ -62,3 +65,7 @@ jobs:
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
+          build-args: |
+            ${{ matrix.name == 'frontend' && format('VITE_GA_MEASUREMENT_ID={0}', secrets.VITE_GA_MEASUREMENT_ID) || '' }}
+          cache-from: type=registry,ref=${{ matrix.image }}:cache-main
+          cache-to: type=registry,ref=${{ matrix.image }}:cache-main,mode=max


### PR DESCRIPTION
**Changes:**
 * Add docker/setup-buildx-action step (required for BuildKit cache export/import)
 * Add registry-based cache-from/cache-to with mode=max to build-push step
 * Cache tags use :cache-main prefix per service to avoid overwriting production image tags
 * Fix GA measurement ID not passed to frontend build during CI