### PR TITLE
feat: add Compare button to event detail and always-visible comparisons section

### DIFF
--- a/frontend/src/routes/__tests__/CompareCandidatesFlowStub.svelte
+++ b/frontend/src/routes/__tests__/CompareCandidatesFlowStub.svelte
@@ -1,0 +1,13 @@
+<script lang="ts">
+  import type { ActivityRow } from '../../lib/types';
+
+  interface Props {
+    activityRows?: ActivityRow[];
+    onCompare?: (eventIds: string[], suggestedFolderId?: string | null) => void;
+  }
+  let { activityRows: _activityRows = [], onCompare: _onCompare }: Props = $props();
+
+  export function openForEvent(_eventId: string) {
+    // stub - no-op
+  }
+</script>

--- a/frontend/src/routes/__tests__/comparison-view.test.ts
+++ b/frontend/src/routes/__tests__/comparison-view.test.ts
@@ -119,7 +119,8 @@ describe('ComparisonView', () => {
     });
   });
 
-  it('Back button when new comparison with no back param pushes to /', async () => {
+  it('Back button when new comparison with no back param calls history.back()', async () => {
+    const mockHistoryBack = vi.spyOn(history, 'back').mockImplementation(() => {});
     render(ComparisonView, {
       props: { params: { id: 'new' }, query: { events: 'evt-1,evt-2' } },
     });
@@ -129,7 +130,8 @@ describe('ComparisonView', () => {
       ).toBeInTheDocument();
     });
     await fireEvent.click(screen.getByRole('button', { name: '← Back to Workouts' }));
-    expect(mockPush).toHaveBeenCalledWith('/');
+    expect(mockHistoryBack).toHaveBeenCalled();
+    mockHistoryBack.mockRestore();
   });
 
   it('Back button when new comparison with back param pushes to folder URL', async () => {

--- a/frontend/src/routes/__tests__/event-detail.test.ts
+++ b/frontend/src/routes/__tests__/event-detail.test.ts
@@ -4,12 +4,14 @@ import EventDetail from '../event-detail.svelte';
 import { eventDetailFixture, activityFixture } from '../../test/fixtures/event-detail';
 import { streamsNoLocationFixture, streamsLatLngFixture } from '../../test/fixtures/streams';
 import type { EventDetail as EventDetailType } from '../../lib/types';
+import type { ComparisonSummary } from '../../lib/api/comparisons';
 
 const mockGetEvent = vi.fn();
 const mockGetStreams = vi.fn();
 const mockGetActivityTypes = vi.fn();
 const mockGetDevices = vi.fn();
 const mockUpdateActivity = vi.fn();
+const mockGetComparisonsByEventIds = vi.fn();
 const mockPush = vi.fn();
 
 vi.mock('../../lib/api', () => ({
@@ -18,6 +20,10 @@ vi.mock('../../lib/api', () => ({
   getActivityTypes: (...args: unknown[]) => mockGetActivityTypes(...args),
   getDevices: (...args: unknown[]) => mockGetDevices(...args),
   updateActivity: (...args: unknown[]) => mockUpdateActivity(...args),
+}));
+
+vi.mock('../../lib/api/comparisons', () => ({
+  getComparisonsByEventIds: (...args: unknown[]) => mockGetComparisonsByEventIds(...args),
 }));
 
 vi.mock('svelte-spa-router', () => ({
@@ -29,6 +35,11 @@ vi.mock('../../lib/components/RouteMap.svelte', async () => {
   return { default: mod.default };
 });
 
+vi.mock('../../lib/components/workouts/CompareCandidatesFlow.svelte', async () => {
+  const mod = await import('./CompareCandidatesFlowStub.svelte');
+  return { default: mod.default };
+});
+
 describe('EventDetail', () => {
   beforeEach(() => {
     mockGetEvent.mockReset();
@@ -36,6 +47,7 @@ describe('EventDetail', () => {
     mockGetActivityTypes.mockResolvedValue(['running', 'cycling']);
     mockGetDevices.mockResolvedValue(['Garmin Forerunner 945', 'Wahoo Elemnt']);
     mockUpdateActivity.mockReset();
+    mockGetComparisonsByEventIds.mockReset().mockResolvedValue([]);
     mockPush.mockReset();
     vi.stubGlobal(
       'ResizeObserver',
@@ -375,6 +387,83 @@ describe('EventDetail', () => {
     render(EventDetail, { props: { params: { id: 'evt-1' } } });
     await waitFor(() => {
       expect(screen.getByText('Event not found.')).toBeInTheDocument();
+    });
+  });
+
+  describe('Related comparisons section', () => {
+    it('always renders the comparisons section header and Compare button', async () => {
+      mockGetEvent.mockResolvedValue(eventDetailFixture);
+      render(EventDetail, { props: { params: { id: 'evt-1' } } });
+      await waitFor(() => {
+        expect(screen.getByText('Morning Run')).toBeInTheDocument();
+      });
+      expect(screen.getByText(/In comparisons/)).toBeInTheDocument();
+      expect(
+        screen.getByRole('button', { name: /Compare with another event/ })
+      ).toBeInTheDocument();
+    });
+
+    it('shows "Not in any comparisons yet." when comparisons list is empty', async () => {
+      mockGetEvent.mockResolvedValue(eventDetailFixture);
+      mockGetComparisonsByEventIds.mockResolvedValue([]);
+      render(EventDetail, { props: { params: { id: 'evt-1' } } });
+      await waitFor(() => {
+        expect(screen.getByText('Morning Run')).toBeInTheDocument();
+      });
+      await waitFor(() => {
+        expect(screen.getByText('Not in any comparisons yet.')).toBeInTheDocument();
+      });
+    });
+
+    it('shows comparisons loading state inside the section', async () => {
+      mockGetEvent.mockResolvedValue(eventDetailFixture);
+      mockGetComparisonsByEventIds.mockReturnValue(new Promise(() => {}));
+      render(EventDetail, { props: { params: { id: 'evt-1' } } });
+      await waitFor(() => {
+        expect(screen.getByText('Morning Run')).toBeInTheDocument();
+      });
+      await waitFor(() => {
+        expect(screen.getByText('Loading related comparisons...')).toBeInTheDocument();
+      });
+      expect(screen.getByText(/In comparisons/)).toBeInTheDocument();
+    });
+
+    it('shows comparisons error state inside the section', async () => {
+      mockGetEvent.mockResolvedValue(eventDetailFixture);
+      mockGetComparisonsByEventIds.mockRejectedValue(new Error('Failed to fetch comparisons'));
+      render(EventDetail, { props: { params: { id: 'evt-1' } } });
+      await waitFor(() => {
+        expect(screen.getByText('Morning Run')).toBeInTheDocument();
+      });
+      await waitFor(() => {
+        expect(screen.getByText('Failed to fetch comparisons')).toBeInTheDocument();
+      });
+      expect(screen.getByText(/In comparisons/)).toBeInTheDocument();
+    });
+
+    it('lists related comparisons when they exist', async () => {
+      const comparisons: ComparisonSummary[] = [
+        { id: 'cmp-1', name: 'Morning Run vs Interval Run' },
+        { id: 'cmp-2', name: 'Easy Run vs Long Run' },
+      ];
+      mockGetEvent.mockResolvedValue(eventDetailFixture);
+      mockGetComparisonsByEventIds.mockResolvedValue(comparisons);
+      render(EventDetail, { props: { params: { id: 'evt-1' } } });
+      await waitFor(() => {
+        expect(screen.getByText('Morning Run vs Interval Run')).toBeInTheDocument();
+      });
+      expect(screen.getByText('Easy Run vs Long Run')).toBeInTheDocument();
+      expect(screen.getByText('In comparisons (2)')).toBeInTheDocument();
+    });
+
+    it('clicking "Compare with another event" does not throw', async () => {
+      mockGetEvent.mockResolvedValue(eventDetailFixture);
+      render(EventDetail, { props: { params: { id: 'evt-1' } } });
+      await waitFor(() => {
+        expect(screen.getByText('Morning Run')).toBeInTheDocument();
+      });
+      const compareBtn = screen.getByRole('button', { name: /Compare with another event/ });
+      await fireEvent.click(compareBtn);
     });
   });
 });

--- a/frontend/src/routes/comparison-view.svelte
+++ b/frontend/src/routes/comparison-view.svelte
@@ -564,7 +564,7 @@
       } else if (backFolderFromQueryState) {
         push(buildFolderHash(backFolderFromQueryState));
       } else {
-        push('/');
+        history.back();
       }
     }}
   >

--- a/frontend/src/routes/event-detail.svelte
+++ b/frontend/src/routes/event-detail.svelte
@@ -33,8 +33,17 @@
   import ExportButton from '../lib/components/ExportButton.svelte';
   import { exportAsPng } from '../lib/utils/export-image';
   import { buildFolderHash } from '../lib/stores/folders.svelte';
+  import CompareCandidatesFlow from '../lib/components/workouts/CompareCandidatesFlow.svelte';
+  import type { ActivityRow } from '../lib/types';
 
   const id = $derived(params?.id ?? '');
+
+  let compareCandidatesFlow: CompareCandidatesFlow | undefined = $state(undefined);
+
+  const eventActivityRows = $derived.by((): ActivityRow[] => {
+    if (!eventDetail) return [];
+    return [{ event: eventDetail.event, activity: eventDetail.activities[0] }];
+  });
 
   let backFolderId = $state<string | null>(null);
   let powerCurveSectionEl = $state<HTMLElement | null>(null);
@@ -554,13 +563,35 @@
     </div>
 
     <!-- Related Comparisons Section -->
-    {#if relatedComparisons.length > 0}
-      <div class="mt-6 overflow-hidden rounded-xl border border-border bg-card shadow-sm">
-        <div class="border-b border-border px-6 py-4">
-          <h3 class="text-base font-semibold text-text-primary">
-            In comparisons ({relatedComparisons.length})
-          </h3>
+    <div class="mt-6 overflow-hidden rounded-xl border border-border bg-card shadow-sm">
+      <div class="flex items-center justify-between border-b border-border px-6 py-4">
+        <h3 class="text-base font-semibold text-text-primary">
+          In comparisons ({relatedComparisons.length})
+        </h3>
+        <button
+          type="button"
+          class="inline-flex h-9 items-center gap-1.5 rounded-md border border-border bg-card px-3 text-sm font-medium text-text-primary shadow-sm hover:bg-card-hover focus:outline-none focus:ring-2 focus:ring-accent focus:ring-offset-2 focus:ring-offset-transparent"
+          onclick={() => compareCandidatesFlow?.openForEvent(id)}
+        >
+          <span class="material-icons text-[1.15em] leading-none" aria-hidden="true">compare</span>
+          Compare with another event
+        </button>
+      </div>
+      {#if relatedComparisonsLoading}
+        <div class="p-4">
+          <div class="flex items-center gap-2 text-text-secondary">
+            <span class="material-icons animate-spin text-base">refresh</span>
+            <span class="text-sm">Loading related comparisons...</span>
+          </div>
         </div>
+      {:else if relatedComparisonsError}
+        <div class="p-4">
+          <div class="flex items-center gap-2 text-danger">
+            <span class="material-icons text-base">error_outline</span>
+            <span class="text-sm">{relatedComparisonsError}</span>
+          </div>
+        </div>
+      {:else if relatedComparisons.length > 0}
         <div class="divide-y divide-border">
           {#each relatedComparisons as comparison (comparison.id)}
             <div class="flex items-center justify-between px-6 py-3 hover:bg-surface/50">
@@ -576,22 +607,10 @@
             </div>
           {/each}
         </div>
-      </div>
-    {:else if relatedComparisonsLoading}
-      <div class="mt-6 rounded-xl border border-border bg-card p-4">
-        <div class="flex items-center gap-2 text-text-secondary">
-          <span class="material-icons animate-spin text-base">refresh</span>
-          <span class="text-sm">Loading related comparisons...</span>
-        </div>
-      </div>
-    {:else if relatedComparisonsError}
-      <div class="mt-6 rounded-xl border border-border bg-card p-4">
-        <div class="flex items-center gap-2 text-danger">
-          <span class="material-icons text-base">error_outline</span>
-          <span class="text-sm">{relatedComparisonsError}</span>
-        </div>
-      </div>
-    {/if}
+      {:else}
+        <div class="px-6 py-4 text-sm text-text-secondary">Not in any comparisons yet.</div>
+      {/if}
+    </div>
 
     {#if locationAvailable && !streamsLoading}
       <div class="mt-6 overflow-hidden rounded-xl border border-border shadow-sm">
@@ -638,3 +657,14 @@
     <p class="text-text-secondary">Event not found.</p>
   {/if}
 </section>
+
+<CompareCandidatesFlow
+  bind:this={compareCandidatesFlow}
+  activityRows={eventActivityRows}
+  onCompare={(eventIds, suggestedFolderId) => {
+    const params = new URLSearchParams();
+    params.set('events', eventIds.join(','));
+    if (suggestedFolderId) params.set('folder', suggestedFolderId);
+    push(`/compare/new?${params.toString()}`);
+  }}
+/>


### PR DESCRIPTION
**Changes:**
 * Always show the "In comparisons" section (with loading/error/empty states) instead of conditionally rendering it
 * Add "Compare with another event" button to the comparisons section header that opens CompareCandidatesFlow
 * Change comparison-view back button (no back param) to call history.back() instead of push('/')
 * Mock getComparisonsByEventIds and CompareCandidatesFlow in event-detail tests
 * Add 6 new tests covering the always-visible section, empty/loading/error states, comparisons list, and button click
 * Update comparison-view test to assert history.back() is called