### PR TITLE
feat: TCX/GPX export + fix calories export and comparison candidates

### DIFF
--- a/backend/docs/openapi.yaml
+++ b/backend/docs/openapi.yaml
@@ -750,6 +750,59 @@ paths:
         "404":
           $ref: "#/components/responses/NotFound"
 
+  /api/events/{id}/export/tcx:
+    get:
+      tags: [events]
+      summary: Export event as TCX
+      description: >
+        Returns a TCX file reconstructed from stored event, activity, stats, and stream data.
+        The original uploaded file is not retained; this is a best-effort reconstruction.
+      parameters:
+        - $ref: "#/components/parameters/eventId"
+      responses:
+        "200":
+          description: TCX file download
+          content:
+            application/xml:
+              schema:
+                type: string
+          headers:
+            Content-Disposition:
+              schema:
+                type: string
+                example: 'attachment; filename="Morning Run.tcx"'
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "404":
+          $ref: "#/components/responses/NotFound"
+
+  /api/events/{id}/export/gpx:
+    get:
+      tags: [events]
+      summary: Export event route as GPX
+      description: >
+        Returns a GPX file reconstructed from stored GPS and stream data.
+        Only available when the event contains GPS streams (Latitude + Longitude or Position).
+        Returns 404 if the event has no GPS data.
+      parameters:
+        - $ref: "#/components/parameters/eventId"
+      responses:
+        "200":
+          description: GPX file download
+          content:
+            application/gpx+xml:
+              schema:
+                type: string
+          headers:
+            Content-Disposition:
+              schema:
+                type: string
+                example: 'attachment; filename="Morning Run.gpx"'
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "404":
+          $ref: "#/components/responses/NotFound"
+
   /api/events/{id}/activities/{activityId}:
     patch:
       tags: [events]

--- a/backend/src/routes/events.js
+++ b/backend/src/routes/events.js
@@ -11,6 +11,7 @@ const { deleteEventById } = require('../services/event-delete-service');
 const { getStreamsForActivity } = require('../services/stream-service');
 const { updateActivity } = require('../services/activity-service');
 const { updateEventFolder } = require('../services/event-update-service');
+const { exportEventAsTcx, exportEventAsGpx } = require('../services/export-service');
 const { asyncHandler } = require('../middleware/async-handler');
 const { uploadLimiter } = require('../middleware/rate-limit');
 const { ValidationError, NotFoundError } = require('../errors');
@@ -70,6 +71,32 @@ router.get(
       { userId: req.userId }
     );
     res.json(result);
+  })
+);
+
+// GET /api/events/:id/export/tcx (must come before /:id route)
+router.get(
+  '/:id/export/tcx',
+  validateEventId,
+  asyncHandler(async (req, res) => {
+    const result = await exportEventAsTcx(req.params.id, { userId: req.userId });
+    if (!result) throw new NotFoundError('Event not found');
+    res.setHeader('Content-Type', 'application/xml');
+    res.setHeader('Content-Disposition', `attachment; filename="${result.name}.tcx"`);
+    res.send(result.xml);
+  })
+);
+
+// GET /api/events/:id/export/gpx (must come before /:id route)
+router.get(
+  '/:id/export/gpx',
+  validateEventId,
+  asyncHandler(async (req, res) => {
+    const result = await exportEventAsGpx(req.params.id, { userId: req.userId });
+    if (!result) throw new NotFoundError('Event not found or no GPS data');
+    res.setHeader('Content-Type', 'application/gpx+xml');
+    res.setHeader('Content-Disposition', `attachment; filename="${result.name}.gpx"`);
+    res.send(result.xml);
   })
 );
 

--- a/backend/src/services/export-service.js
+++ b/backend/src/services/export-service.js
@@ -1,0 +1,94 @@
+'use strict';
+
+const defaultDb = require('../db');
+const eventRepository = require('../repositories/event-repository');
+const activityRepository = require('../repositories/activity-repository');
+const streamRepository = require('../repositories/stream-repository');
+const { buildTcx, sanitizeFilename } = require('../utils/tcx-builder');
+const { buildGpx } = require('../utils/gpx-builder');
+const { parseJSONField, aggregateStats } = require('../utils/transforms');
+
+/**
+ * Groups stream rows by activity id and parses the JSON data field.
+ * @param {object[]} streamRows
+ * @param {string[]} activityIds
+ * @returns {Record<string, Record<string, Array<{time: number, value: any}>>>}
+ */
+function groupAndParseStreams(streamRows, activityIds) {
+  const result = {};
+  for (const id of activityIds) {
+    result[id] = {};
+  }
+  for (const row of streamRows) {
+    const data = parseJSONField(row.data, []);
+    if (!result[row.activity_id]) result[row.activity_id] = {};
+    result[row.activity_id][row.type] = data;
+  }
+  return result;
+}
+
+/**
+ * Exports an event as a TCX XML document.
+ * @param {string} eventId
+ * @param {object} opts - must include opts.userId
+ * @returns {Promise<{xml: string, name: string}|null>} null if event not found
+ */
+async function exportEventAsTcx(eventId, opts = {}) {
+  const db = opts.db ?? defaultDb;
+  const repoOpts = { ...opts, db };
+
+  const event = await eventRepository.findById(eventId, repoOpts);
+  if (!event) return null;
+
+  const activities = await activityRepository.findByEventId(eventId, repoOpts);
+  const activityIds = activities.map((a) => a.id);
+
+  const [activityStatRows, streamRows] = await Promise.all([
+    activityIds.length
+      ? activityRepository.getStatsByActivityIds(activityIds, repoOpts)
+      : Promise.resolve([]),
+    activityIds.length
+      ? streamRepository.findAllByActivityIds(activityIds, repoOpts)
+      : Promise.resolve([]),
+  ]);
+
+  const statsByActivityId = aggregateStats(activityStatRows, 'activity_id');
+  const streamsByActivityId = groupAndParseStreams(streamRows, activityIds);
+
+  const xml = buildTcx(event, activities, statsByActivityId, streamsByActivityId);
+  const name = sanitizeFilename(event.name, `event-${eventId}`);
+
+  return { xml, name };
+}
+
+/**
+ * Exports an event as a GPX XML document.
+ * Returns null if the event is not found or has no GPS streams.
+ * @param {string} eventId
+ * @param {object} opts - must include opts.userId
+ * @returns {Promise<{xml: string, name: string}|null>}
+ */
+async function exportEventAsGpx(eventId, opts = {}) {
+  const db = opts.db ?? defaultDb;
+  const repoOpts = { ...opts, db };
+
+  const event = await eventRepository.findById(eventId, repoOpts);
+  if (!event) return null;
+
+  const activities = await activityRepository.findByEventId(eventId, repoOpts);
+  const activityIds = activities.map((a) => a.id);
+
+  const streamRows = activityIds.length
+    ? await streamRepository.findAllByActivityIds(activityIds, repoOpts)
+    : [];
+
+  const streamsByActivityId = groupAndParseStreams(streamRows, activityIds);
+
+  const xml = buildGpx(event, activities, streamsByActivityId);
+  if (!xml) return null;
+
+  const name = sanitizeFilename(event.name, `event-${eventId}`);
+  return { xml, name };
+}
+
+module.exports = { exportEventAsTcx, exportEventAsGpx };

--- a/backend/src/utils/gpx-builder.js
+++ b/backend/src/utils/gpx-builder.js
@@ -1,0 +1,131 @@
+'use strict';
+
+/**
+ * Pure GPX XML serializer. No DB dependency.
+ * Only emits trackpoints anchored to GPS coordinates.
+ * Returns null if no activity has GPS data.
+ */
+
+const { buildTrackpoints } = require('./trackpoint-builder');
+
+function escapeXml(str) {
+  if (str == null) return '';
+  return String(str)
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&apos;');
+}
+
+function toIso8601(ms) {
+  return new Date(Number(ms)).toISOString();
+}
+
+/**
+ * Returns true if the stream map contains GPS data.
+ * @param {Record<string, any[]>|null} streamMap
+ * @returns {boolean}
+ */
+function hasGpsStreams(streamMap) {
+  if (!streamMap) return false;
+  const hasSeparate = 'Latitude' in streamMap && 'Longitude' in streamMap;
+  const hasCombined = 'Position' in streamMap;
+  return hasSeparate || hasCombined;
+}
+
+/**
+ * Builds a complete GPX XML document.
+ * Returns null if no activity has GPS streams.
+ * @param {object} event - raw event DB row
+ * @param {object[]} activities - raw activity DB rows
+ * @param {Record<string, Record<string, Array<{time: number, value: any}>>>} streamsByActivityId
+ * @returns {string|null} GPX XML document or null
+ */
+function buildGpx(event, activities, streamsByActivityId) {
+  const gpsActivities = activities.filter((a) => hasGpsStreams(streamsByActivityId[a.id] ?? {}));
+  if (gpsActivities.length === 0) return null;
+
+  const eventName = escapeXml(event.name ?? '');
+  const eventStartIso = toIso8601(event.start_date);
+
+  const segments = gpsActivities
+    .map((activity) => {
+      const streamMap = streamsByActivityId[activity.id] ?? {};
+      const trackpoints = buildTrackpoints(streamMap);
+
+      const tpLines = trackpoints
+        .map((tp) => {
+          const s = tp.streams;
+
+          let lat = s['Latitude'] ?? null;
+          let lon = s['Longitude'] ?? null;
+          if (lat == null && lon == null && s['Position'] != null) {
+            const pos = s['Position'];
+            if (Array.isArray(pos) && pos.length >= 2) {
+              lat = pos[0];
+              lon = pos[1];
+            }
+          }
+
+          // GPX is GPS-anchored — skip trackpoints without resolved coordinates
+          if (lat == null || lon == null) return null;
+
+          const lines = [];
+          lines.push(`      <trkpt lat="${lat}" lon="${lon}">`);
+          if (s['Altitude'] != null) lines.push(`        <ele>${s['Altitude']}</ele>`);
+          lines.push(`        <time>${toIso8601(tp.timeMs)}</time>`);
+
+          const extFields = [];
+          if (s['Heart Rate'] != null)
+            extFields.push(`          <gpxtpx:hr>${s['Heart Rate']}</gpxtpx:hr>`);
+          if (s['Cadence'] != null)
+            extFields.push(`          <gpxtpx:cad>${s['Cadence']}</gpxtpx:cad>`);
+          if (s['Temperature'] != null)
+            extFields.push(`          <gpxtpx:atemp>${s['Temperature']}</gpxtpx:atemp>`);
+          if (s['Power'] != null)
+            extFields.push(`          <gpxtpx:power>${s['Power']}</gpxtpx:power>`);
+
+          if (extFields.length > 0) {
+            lines.push('        <extensions>');
+            lines.push('          <gpxtpx:TrackPointExtension>');
+            lines.push(...extFields);
+            lines.push('          </gpxtpx:TrackPointExtension>');
+            lines.push('        </extensions>');
+          }
+
+          lines.push('      </trkpt>');
+          return lines.join('\n');
+        })
+        .filter(Boolean);
+
+      if (tpLines.length === 0) return null;
+
+      return ['    <trkseg>', ...tpLines, '    </trkseg>'].join('\n');
+    })
+    .filter(Boolean);
+
+  if (segments.length === 0) return null;
+
+  const lines = [
+    '<?xml version="1.0" encoding="UTF-8"?>',
+    '<gpx version="1.1" creator="OpenFitLab"',
+    '  xmlns="http://www.topografix.com/GPX/1/1"',
+    '  xmlns:gpxtpx="http://www.garmin.com/xmlschemas/TrackPointExtension/v1"',
+    '  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"',
+    '  xsi:schemaLocation="http://www.topografix.com/GPX/1/1 http://www.topografix.com/GPX/1/1/gpx.xsd http://www.garmin.com/xmlschemas/TrackPointExtension/v1 http://www.garmin.com/xmlschemas/TrackPointExtensionv1.xsd">',
+    '  <metadata>',
+    `    <name>${eventName}</name>`,
+    `    <time>${eventStartIso}</time>`,
+    '  </metadata>',
+    '  <trk>',
+    `    <name>${eventName}</name>`,
+    ...segments,
+    '  </trk>',
+    '</gpx>',
+  ];
+
+  return lines.join('\n');
+}
+
+module.exports = { buildGpx, hasGpsStreams };

--- a/backend/src/utils/tcx-builder.js
+++ b/backend/src/utils/tcx-builder.js
@@ -1,0 +1,178 @@
+'use strict';
+
+/**
+ * Pure TCX XML serializer. No DB dependency.
+ * Accepts plain objects (already-fetched DB data).
+ */
+
+const { buildTrackpoints } = require('./trackpoint-builder');
+
+function escapeXml(str) {
+  if (str == null) return '';
+  return String(str)
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&apos;');
+}
+
+function toIso8601(ms) {
+  return new Date(Number(ms)).toISOString();
+}
+
+/**
+ * Maps stored activity type to TCX Sport attribute.
+ * @param {string|null} activityType
+ * @returns {'Running'|'Biking'|'Other'}
+ */
+function toTcxSport(activityType) {
+  if (!activityType) return 'Other';
+  const lower = String(activityType).toLowerCase();
+  if (lower === 'running') return 'Running';
+  if (lower === 'cycling') return 'Biking';
+  return 'Other';
+}
+
+/**
+ * Sanitises a string for safe use as a filename.
+ * @param {string|null} name
+ * @param {string} fallback
+ * @returns {string}
+ */
+function sanitizeFilename(name, fallback) {
+  if (!name || typeof name !== 'string') return fallback;
+  const sanitized = name
+    .replace(/[/\\:*?"<>|]/g, '_')
+    .replace(/[^\x20-\x7E]/g, '_') // strip non-ASCII
+    .trim()
+    .replace(/_+/g, '_')
+    .substring(0, 100);
+  return sanitized || fallback;
+}
+
+function buildTrackpointXml(tp) {
+  const s = tp.streams;
+  const lines = [];
+
+  lines.push('          <Trackpoint>');
+  lines.push(`            <Time>${toIso8601(tp.timeMs)}</Time>`);
+
+  // Resolve position — prefer separate Latitude/Longitude; fall back to Position [lat, lon]
+  let lat = s['Latitude'] ?? null;
+  let lon = s['Longitude'] ?? null;
+  if (lat == null && lon == null && s['Position'] != null) {
+    const pos = s['Position'];
+    if (Array.isArray(pos) && pos.length >= 2) {
+      lat = pos[0];
+      lon = pos[1];
+    }
+  }
+  if (lat != null && lon != null) {
+    lines.push('            <Position>');
+    lines.push(`              <LatitudeDegrees>${lat}</LatitudeDegrees>`);
+    lines.push(`              <LongitudeDegrees>${lon}</LongitudeDegrees>`);
+    lines.push('            </Position>');
+  }
+
+  if (s['Altitude'] != null)
+    lines.push(`            <AltitudeMeters>${s['Altitude']}</AltitudeMeters>`);
+  if (s['Distance'] != null)
+    lines.push(`            <DistanceMeters>${s['Distance']}</DistanceMeters>`);
+  if (s['Heart Rate'] != null)
+    lines.push(`            <HeartRateBpm><Value>${s['Heart Rate']}</Value></HeartRateBpm>`);
+  if (s['Cadence'] != null) lines.push(`            <Cadence>${s['Cadence']}</Cadence>`);
+
+  if (s['Speed'] != null || s['Power'] != null) {
+    lines.push('            <Extensions>');
+    lines.push('              <ns3:TPX>');
+    if (s['Speed'] != null) lines.push(`                <ns3:Speed>${s['Speed']}</ns3:Speed>`);
+    if (s['Power'] != null) lines.push(`                <ns3:Watts>${s['Power']}</ns3:Watts>`);
+    lines.push('              </ns3:TPX>');
+    lines.push('            </Extensions>');
+  }
+
+  lines.push('          </Trackpoint>');
+  return lines.join('\n');
+}
+
+/**
+ * Builds a complete TCX XML document.
+ * @param {object} event - raw event DB row
+ * @param {object[]} activities - raw activity DB rows
+ * @param {Record<string, Record<string, number>>} statsByActivityId
+ * @param {Record<string, Record<string, Array<{time: number, value: any}>>>} streamsByActivityId
+ * @returns {string} TCX XML document
+ */
+function buildTcx(event, activities, statsByActivityId, streamsByActivityId) {
+  const sport = toTcxSport(activities[0]?.type ?? null);
+  const eventStartIso = toIso8601(event.start_date);
+
+  const lapParts = activities.map((activity) => {
+    const stats = statsByActivityId[activity.id] ?? {};
+    const streamMap = streamsByActivityId[activity.id] ?? {};
+    const startIso = activity.start_date != null ? toIso8601(activity.start_date) : eventStartIso;
+    const trackpoints = buildTrackpoints(streamMap);
+
+    const statLines = [];
+    if (stats['Duration'] != null)
+      statLines.push(`        <TotalTimeSeconds>${stats['Duration']}</TotalTimeSeconds>`);
+    if (stats['Distance'] != null)
+      statLines.push(`        <DistanceMeters>${stats['Distance']}</DistanceMeters>`);
+    if (stats['Maximum Speed'] != null)
+      statLines.push(`        <MaximumSpeed>${stats['Maximum Speed']}</MaximumSpeed>`);
+    if (stats['Energy'] != null) statLines.push(`        <Calories>${stats['Energy']}</Calories>`);
+    if (stats['Average Heart Rate'] != null)
+      statLines.push(
+        `        <AverageHeartRateBpm><Value>${stats['Average Heart Rate']}</Value></AverageHeartRateBpm>`
+      );
+    if (stats['Maximum Heart Rate'] != null)
+      statLines.push(
+        `        <MaximumHeartRateBpm><Value>${stats['Maximum Heart Rate']}</Value></MaximumHeartRateBpm>`
+      );
+
+    const tpXml = trackpoints.map(buildTrackpointXml).join('\n');
+
+    const parts = [
+      `      <Lap StartTime="${startIso}">`,
+      ...statLines,
+      '        <Intensity>Active</Intensity>',
+      '        <TriggerMethod>Manual</TriggerMethod>',
+      '        <Track>',
+    ];
+    if (tpXml) parts.push(tpXml);
+    parts.push('        </Track>');
+    parts.push('      </Lap>');
+    return parts.join('\n');
+  });
+
+  // Creator uses first activity's device name
+  const deviceName = activities[0]?.device_name ?? null;
+  const creatorParts = deviceName
+    ? [
+        '      <Creator xsi:type="Device_t">',
+        `        <Name>${escapeXml(deviceName)}</Name>`,
+        '      </Creator>',
+      ]
+    : [];
+
+  const lines = [
+    '<?xml version="1.0" encoding="UTF-8"?>',
+    '<TrainingCenterDatabase xmlns="http://www.garmin.com/xmlschemas/TrainingCenterDatabase/v2"',
+    '  xmlns:ns3="http://www.garmin.com/xmlschemas/ActivityExtension/v2"',
+    '  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"',
+    '  xsi:schemaLocation="http://www.garmin.com/xmlschemas/TrainingCenterDatabase/v2 http://www.garmin.com/xmlschemas/TrainingCenterDatabasev2.xsd">',
+    '  <Activities>',
+    `    <Activity Sport="${sport}">`,
+    `      <Id>${eventStartIso}</Id>`,
+    ...lapParts,
+    ...creatorParts,
+    '    </Activity>',
+    '  </Activities>',
+    '</TrainingCenterDatabase>',
+  ];
+
+  return lines.join('\n');
+}
+
+module.exports = { buildTcx, toTcxSport, sanitizeFilename };

--- a/backend/src/utils/trackpoint-builder.js
+++ b/backend/src/utils/trackpoint-builder.js
@@ -1,0 +1,80 @@
+'use strict';
+
+/**
+ * Shared trackpoint alignment utility.
+ * Pure functions — no DB dependency.
+ */
+
+/**
+ * Builds a sorted array of all unique timestamps across all streams.
+ * @param {Record<string, Array<{time: number, value: any}>>} streamMap
+ * @returns {number[]}
+ */
+function buildUnifiedTimeline(streamMap) {
+  const timestamps = new Set();
+  for (const stream of Object.values(streamMap)) {
+    for (const point of stream) {
+      timestamps.add(point.time);
+    }
+  }
+  return Array.from(timestamps).sort((a, b) => a - b);
+}
+
+/**
+ * Binary search for the nearest point within tolerance.
+ * @param {Array<{time: number, value: any}>} stream - must be sorted ascending by time
+ * @param {number} targetMs
+ * @param {number} toleranceMs
+ * @returns {any} value or null if nearest is beyond tolerance
+ */
+function resolveValue(stream, targetMs, toleranceMs = 30000) {
+  if (!stream || stream.length === 0) return null;
+
+  let lo = 0;
+  let hi = stream.length - 1;
+
+  // Find first index with time >= targetMs (or last index if all are < targetMs)
+  while (lo < hi) {
+    const mid = (lo + hi) >>> 1;
+    if (stream[mid].time < targetMs) {
+      lo = mid + 1;
+    } else {
+      hi = mid;
+    }
+  }
+
+  // Compare lo and lo-1 to find the nearest
+  let bestIdx = lo;
+  if (lo > 0) {
+    const prevDiff = Math.abs(stream[lo - 1].time - targetMs);
+    const currDiff = Math.abs(stream[lo].time - targetMs);
+    if (prevDiff < currDiff) bestIdx = lo - 1;
+  }
+
+  const diff = Math.abs(stream[bestIdx].time - targetMs);
+  return diff <= toleranceMs ? stream[bestIdx].value : null;
+}
+
+/**
+ * Builds unified trackpoints from a stream map.
+ * @param {Record<string, Array<{time: number, value: any}>>} streamMap
+ * @returns {Array<{timeMs: number, streams: Record<string, any>}>}
+ */
+function buildTrackpoints(streamMap) {
+  const types = Object.keys(streamMap);
+  if (types.length === 0) return [];
+
+  const timeline = buildUnifiedTimeline(streamMap);
+  return timeline.map((timeMs) => {
+    const streams = {};
+    for (const type of types) {
+      const val = resolveValue(streamMap[type], timeMs);
+      if (val !== null) {
+        streams[type] = val;
+      }
+    }
+    return { timeMs, streams };
+  });
+}
+
+module.exports = { buildUnifiedTimeline, resolveValue, buildTrackpoints };

--- a/backend/test/unit/routes/events-routes.test.js
+++ b/backend/test/unit/routes/events-routes.test.js
@@ -22,6 +22,7 @@ const {
   processUpload,
   buildUploadResults,
 } = require('../../../src/services/event-upload-service');
+const exportService = require('../../../src/services/export-service');
 const eventsRouterModule = require('../../../src/routes/events');
 const { errorHandler } = require('../../../src/middleware/error-handler');
 const fs = require('fs');
@@ -415,6 +416,68 @@ describe('Events route HTTP handler coverage', () => {
       deepStrictEqual(res.body, { error: 'Event not found' });
     } finally {
       eventDeleteService.deleteEventById.mock.restore();
+      delete require.cache[EVENTS_ROUTER_PATH];
+    }
+  });
+
+  it('GET /:id/export/tcx returns 200 with correct headers when service returns result', async () => {
+    mock.method(exportService, 'exportEventAsTcx', async () => ({
+      xml: '<?xml version="1.0"?><TrainingCenterDatabase/>',
+      name: 'Morning Run',
+    }));
+    try {
+      const router = getFreshEventsRouter();
+      const app = createEventsApp(router);
+      const res = await request(app).get(`/api/events/${EVENT_ID}/export/tcx`).expect(200);
+      strictEqual(res.headers['content-type'], 'application/xml; charset=utf-8');
+      ok(res.headers['content-disposition'].includes('attachment'));
+      ok(res.headers['content-disposition'].includes('Morning Run.tcx'));
+    } finally {
+      exportService.exportEventAsTcx.mock.restore();
+      delete require.cache[EVENTS_ROUTER_PATH];
+    }
+  });
+
+  it('GET /:id/export/tcx returns 404 when service returns null', async () => {
+    mock.method(exportService, 'exportEventAsTcx', async () => null);
+    try {
+      const router = getFreshEventsRouter();
+      const app = createEventsApp(router);
+      const res = await request(app).get(`/api/events/${EVENT_ID}/export/tcx`).expect(404);
+      deepStrictEqual(res.body, { error: 'Event not found' });
+    } finally {
+      exportService.exportEventAsTcx.mock.restore();
+      delete require.cache[EVENTS_ROUTER_PATH];
+    }
+  });
+
+  it('GET /:id/export/gpx returns 200 with correct headers when service returns result', async () => {
+    mock.method(exportService, 'exportEventAsGpx', async () => ({
+      xml: '<?xml version="1.0"?><gpx/>',
+      name: 'Morning Run',
+    }));
+    try {
+      const router = getFreshEventsRouter();
+      const app = createEventsApp(router);
+      const res = await request(app).get(`/api/events/${EVENT_ID}/export/gpx`).expect(200);
+      strictEqual(res.headers['content-type'], 'application/gpx+xml; charset=utf-8');
+      ok(res.headers['content-disposition'].includes('attachment'));
+      ok(res.headers['content-disposition'].includes('Morning Run.gpx'));
+    } finally {
+      exportService.exportEventAsGpx.mock.restore();
+      delete require.cache[EVENTS_ROUTER_PATH];
+    }
+  });
+
+  it('GET /:id/export/gpx returns 404 when service returns null', async () => {
+    mock.method(exportService, 'exportEventAsGpx', async () => null);
+    try {
+      const router = getFreshEventsRouter();
+      const app = createEventsApp(router);
+      const res = await request(app).get(`/api/events/${EVENT_ID}/export/gpx`).expect(404);
+      deepStrictEqual(res.body, { error: 'Event not found or no GPS data' });
+    } finally {
+      exportService.exportEventAsGpx.mock.restore();
       delete require.cache[EVENTS_ROUTER_PATH];
     }
   });

--- a/backend/test/unit/services/export-service.test.js
+++ b/backend/test/unit/services/export-service.test.js
@@ -1,0 +1,151 @@
+const { describe, it } = require('node:test');
+const { strictEqual, ok } = require('node:assert/strict');
+const { makeFakeDb } = require('../../helpers/fake-db');
+const { exportEventAsTcx, exportEventAsGpx } = require('../../../src/services/export-service');
+
+const EVENT_ID = 'evt-uuid-1';
+const ACT_ID = 'act-uuid-1';
+const USER_ID = 'user-1';
+
+const fakeEventRow = {
+  id: EVENT_ID,
+  start_date: 1700000000000,
+  name: 'Morning Run',
+  end_date: null,
+  folder_id: null,
+  description: null,
+  is_merge: 0,
+  src_file_type: 'tcx',
+  start_timezone: null,
+  end_timezone: null,
+};
+
+const fakeActivityRow = {
+  id: ACT_ID,
+  event_id: EVENT_ID,
+  name: null,
+  start_date: 1700000000000,
+  end_date: null,
+  type: 'Running',
+  device_name: 'Garmin',
+  start_timezone: null,
+  end_timezone: null,
+  created_at: 1700000000000,
+};
+
+const fakeGpsStreamRow = {
+  id: `${ACT_ID}_Latitude`,
+  activity_id: ACT_ID,
+  type: 'Latitude',
+  data: JSON.stringify([{ time: 1700000000000, value: 51.5 }]),
+};
+
+const fakeLonStreamRow = {
+  id: `${ACT_ID}_Longitude`,
+  activity_id: ACT_ID,
+  type: 'Longitude',
+  data: JSON.stringify([{ time: 1700000000000, value: -0.1 }]),
+};
+
+function makeDb(eventRow, activityRows, statRows, streamRows) {
+  return makeFakeDb(async (sql) => {
+    if (sql.includes('FROM events') && sql.includes('WHERE id')) return eventRow ? [eventRow] : [];
+    if (sql.includes('FROM activities') && sql.includes('WHERE a.event_id')) return activityRows;
+    if (sql.includes('FROM activity_stats')) return statRows;
+    if (sql.includes('FROM streams')) return streamRows;
+    return [];
+  });
+}
+
+describe('exportEventAsTcx', () => {
+  it('returns null when event not found', async () => {
+    const db = makeDb(null, [], [], []);
+    const result = await exportEventAsTcx(EVENT_ID, { db, userId: USER_ID });
+    strictEqual(result, null);
+  });
+
+  it('calls findById with correct eventId and userId', async () => {
+    let capturedParams;
+    const db = makeFakeDb(async (sql, params) => {
+      if (sql.includes('FROM events') && sql.includes('WHERE id')) {
+        capturedParams = params;
+        return [];
+      }
+      return [];
+    });
+    await exportEventAsTcx(EVENT_ID, { db, userId: USER_ID });
+    ok(capturedParams.includes(EVENT_ID));
+    ok(capturedParams.includes(USER_ID));
+  });
+
+  it('returns { xml, name } when event found', async () => {
+    const db = makeDb(fakeEventRow, [fakeActivityRow], [], []);
+    const result = await exportEventAsTcx(EVENT_ID, { db, userId: USER_ID });
+    ok(result != null);
+    ok(typeof result.xml === 'string');
+    ok(result.xml.startsWith('<?xml'));
+    ok(typeof result.name === 'string');
+    strictEqual(result.name, 'Morning Run');
+  });
+
+  it('parses stream JSON data field before passing to builder', async () => {
+    const db = makeDb(fakeEventRow, [fakeActivityRow], [], [fakeGpsStreamRow, fakeLonStreamRow]);
+    const result = await exportEventAsTcx(EVENT_ID, { db, userId: USER_ID });
+    ok(result != null);
+    // TCX should contain the GPS Position elements since streams were parsed
+    ok(result.xml.includes('<Position>'));
+  });
+
+  it('uses sanitized event name as filename', async () => {
+    const eventWithSpecialChars = { ...fakeEventRow, name: 'run/2024:01' };
+    const db = makeDb(eventWithSpecialChars, [fakeActivityRow], [], []);
+    const result = await exportEventAsTcx(EVENT_ID, { db, userId: USER_ID });
+    ok(result != null);
+    ok(!result.name.includes('/'));
+    ok(!result.name.includes(':'));
+  });
+
+  it('handles event with no activities', async () => {
+    const db = makeDb(fakeEventRow, [], [], []);
+    const result = await exportEventAsTcx(EVENT_ID, { db, userId: USER_ID });
+    ok(result != null);
+    ok(result.xml.includes('<TrainingCenterDatabase'));
+  });
+});
+
+describe('exportEventAsGpx', () => {
+  it('returns null when event not found', async () => {
+    const db = makeDb(null, [], [], []);
+    const result = await exportEventAsGpx(EVENT_ID, { db, userId: USER_ID });
+    strictEqual(result, null);
+  });
+
+  it('returns null when no activity has GPS streams', async () => {
+    const hrStream = {
+      id: `${ACT_ID}_HR`,
+      activity_id: ACT_ID,
+      type: 'Heart Rate',
+      data: JSON.stringify([{ time: 1700000000000, value: 140 }]),
+    };
+    const db = makeDb(fakeEventRow, [fakeActivityRow], [], [hrStream]);
+    const result = await exportEventAsGpx(EVENT_ID, { db, userId: USER_ID });
+    strictEqual(result, null);
+  });
+
+  it('returns { xml, name } when event has GPS streams', async () => {
+    const db = makeDb(fakeEventRow, [fakeActivityRow], [], [fakeGpsStreamRow, fakeLonStreamRow]);
+    const result = await exportEventAsGpx(EVENT_ID, { db, userId: USER_ID });
+    ok(result != null);
+    ok(typeof result.xml === 'string');
+    ok(result.xml.startsWith('<?xml'));
+    ok(result.xml.includes('<gpx'));
+    strictEqual(result.name, 'Morning Run');
+  });
+
+  it('parses stream JSON data field before passing to builder', async () => {
+    const db = makeDb(fakeEventRow, [fakeActivityRow], [], [fakeGpsStreamRow, fakeLonStreamRow]);
+    const result = await exportEventAsGpx(EVENT_ID, { db, userId: USER_ID });
+    ok(result != null);
+    ok(result.xml.includes('<trkpt'));
+  });
+});

--- a/backend/test/unit/utils/gpx-builder.test.js
+++ b/backend/test/unit/utils/gpx-builder.test.js
@@ -1,0 +1,123 @@
+const { describe, it } = require('node:test');
+const { strictEqual, ok } = require('node:assert/strict');
+const { buildGpx, hasGpsStreams } = require('../../../src/utils/gpx-builder');
+
+const baseEvent = { id: 'evt-1', start_date: 1700000000000, name: 'My Ride' };
+const baseActivity = { id: 'act-1', event_id: 'evt-1' };
+
+const gpsStreams = {
+  Latitude: [{ time: 1700000000000, value: 51.5 }],
+  Longitude: [{ time: 1700000000000, value: -0.1 }],
+};
+
+describe('hasGpsStreams', () => {
+  it('returns true with Latitude and Longitude', () => {
+    ok(hasGpsStreams({ Latitude: [], Longitude: [] }));
+  });
+
+  it('returns false without GPS streams', () => {
+    strictEqual(hasGpsStreams({ 'Heart Rate': [] }), false);
+    strictEqual(hasGpsStreams({}), false);
+  });
+
+  it('returns false for null', () => {
+    strictEqual(hasGpsStreams(null), false);
+  });
+
+  it('returns true with Position stream', () => {
+    ok(hasGpsStreams({ Position: [] }));
+  });
+
+  it('returns false with only Latitude (no Longitude)', () => {
+    strictEqual(hasGpsStreams({ Latitude: [] }), false);
+  });
+});
+
+describe('buildGpx', () => {
+  it('output starts with <?xml', () => {
+    const xml = buildGpx(baseEvent, [baseActivity], { 'act-1': gpsStreams });
+    ok(xml.startsWith('<?xml'));
+  });
+
+  it('contains <gpx', () => {
+    const xml = buildGpx(baseEvent, [baseActivity], { 'act-1': gpsStreams });
+    ok(xml.includes('<gpx'));
+  });
+
+  it('returns null when no activity has GPS data', () => {
+    strictEqual(
+      buildGpx(baseEvent, [baseActivity], { 'act-1': { 'Heart Rate': [] } }),
+      null
+    );
+  });
+
+  it('returns null when activities array is empty', () => {
+    strictEqual(buildGpx(baseEvent, [], {}), null);
+  });
+
+  it('single activity with GPS produces one trkseg with trackpoints', () => {
+    const xml = buildGpx(baseEvent, [baseActivity], { 'act-1': gpsStreams });
+    const trksegs = (xml.match(/<trkseg>/g) || []).length;
+    strictEqual(trksegs, 1);
+    ok(xml.includes('<trkpt'));
+  });
+
+  it('trackpoints only emitted where both lat and lon are resolved', () => {
+    // Second lat point at t+60s — lon only has one point at t=0, so at t+60s lon is >30s away
+    const streams = {
+      Latitude: [
+        { time: 1700000000000, value: 51.5 },
+        { time: 1700000060000, value: 51.6 },
+      ],
+      Longitude: [{ time: 1700000000000, value: -0.1 }],
+    };
+    const xml = buildGpx(baseEvent, [baseActivity], { 'act-1': streams });
+    // Only the first trackpoint should appear (lon resolves for t=0, not for t+60s)
+    const trkpts = (xml.match(/<trkpt /g) || []).length;
+    strictEqual(trkpts, 1);
+  });
+
+  it('extension block omitted when no extension fields present', () => {
+    const xml = buildGpx(baseEvent, [baseActivity], { 'act-1': gpsStreams });
+    ok(!xml.includes('<extensions>'));
+  });
+
+  it('extension block includes only present fields', () => {
+    const streams = {
+      ...gpsStreams,
+      'Heart Rate': [{ time: 1700000000000, value: 140 }],
+      Power: [{ time: 1700000000000, value: 250 }],
+    };
+    const xml = buildGpx(baseEvent, [baseActivity], { 'act-1': streams });
+    ok(xml.includes('<gpxtpx:hr>140</gpxtpx:hr>'));
+    ok(xml.includes('<gpxtpx:power>250</gpxtpx:power>'));
+    ok(!xml.includes('<gpxtpx:cad>'));
+    ok(!xml.includes('<gpxtpx:atemp>'));
+  });
+
+  it('Position stream [lat, lon] array is parsed correctly', () => {
+    const streams = {
+      Position: [{ time: 1700000000000, value: [51.5, -0.1] }],
+    };
+    const xml = buildGpx(baseEvent, [baseActivity], { 'act-1': streams });
+    ok(xml != null);
+    ok(xml.includes('lat="51.5"'));
+    ok(xml.includes('lon="-0.1"'));
+  });
+
+  it('multi-activity: activities without GPS skipped, those with GPS get a segment each', () => {
+    const act2 = { id: 'act-2' };
+    const act3 = { id: 'act-3' };
+    const streamsByActivity = {
+      'act-1': gpsStreams,
+      'act-2': { 'Heart Rate': [{ time: 1700000001000, value: 130 }] },
+      'act-3': {
+        Latitude: [{ time: 1700000001000, value: 51.6 }],
+        Longitude: [{ time: 1700000001000, value: -0.2 }],
+      },
+    };
+    const xml = buildGpx(baseEvent, [baseActivity, act2, act3], streamsByActivity);
+    const trksegs = (xml.match(/<trkseg>/g) || []).length;
+    strictEqual(trksegs, 2);
+  });
+});

--- a/backend/test/unit/utils/tcx-builder.test.js
+++ b/backend/test/unit/utils/tcx-builder.test.js
@@ -1,0 +1,169 @@
+const { describe, it } = require('node:test');
+const { strictEqual, ok } = require('node:assert/strict');
+const { buildTcx, toTcxSport, sanitizeFilename } = require('../../../src/utils/tcx-builder');
+
+const baseEvent = { id: 'evt-1', start_date: 1700000000000, name: 'My Run' };
+const baseActivity = {
+  id: 'act-1',
+  event_id: 'evt-1',
+  type: 'Running',
+  start_date: 1700000000000,
+  device_name: null,
+};
+
+describe('toTcxSport', () => {
+  it('maps Running → Running', () => strictEqual(toTcxSport('Running'), 'Running'));
+  it('maps running (lowercase) → Running', () => strictEqual(toTcxSport('running'), 'Running'));
+  it('maps Cycling → Biking', () => strictEqual(toTcxSport('Cycling'), 'Biking'));
+  it('maps cycling (lowercase) → Biking', () => strictEqual(toTcxSport('cycling'), 'Biking'));
+  it('maps Elliptical → Other', () => strictEqual(toTcxSport('Elliptical'), 'Other'));
+  it('maps null → Other', () => strictEqual(toTcxSport(null), 'Other'));
+  it('maps undefined → Other', () => strictEqual(toTcxSport(undefined), 'Other'));
+});
+
+describe('sanitizeFilename', () => {
+  it('replaces illegal chars with underscore', () => {
+    strictEqual(sanitizeFilename('run/2024:01', 'fallback'), 'run_2024_01');
+  });
+
+  it('collapses multiple underscores', () => {
+    strictEqual(sanitizeFilename('run//2024', 'x'), 'run_2024');
+  });
+
+  it('truncates to 100 characters', () => {
+    strictEqual(sanitizeFilename('a'.repeat(150), 'fallback').length, 100);
+  });
+
+  it('falls back when name is empty string', () => {
+    strictEqual(sanitizeFilename('', 'event-1'), 'event-1');
+  });
+
+  it('falls back for null', () => {
+    strictEqual(sanitizeFilename(null, 'event-2'), 'event-2');
+  });
+
+  it('strips non-ASCII characters', () => {
+    const result = sanitizeFilename('café run', 'fallback');
+    ok(!result.includes('é'));
+  });
+});
+
+describe('buildTcx', () => {
+  it('output is a string starting with <?xml', () => {
+    const xml = buildTcx(baseEvent, [baseActivity], {}, { 'act-1': {} });
+    ok(typeof xml === 'string');
+    ok(xml.startsWith('<?xml'));
+  });
+
+  it('contains <TrainingCenterDatabase', () => {
+    const xml = buildTcx(baseEvent, [baseActivity], {}, { 'act-1': {} });
+    ok(xml.includes('<TrainingCenterDatabase'));
+  });
+
+  it('single activity with no streams produces valid XML with empty Track', () => {
+    const xml = buildTcx(baseEvent, [baseActivity], {}, { 'act-1': {} });
+    ok(xml.includes('<Track>'));
+    ok(xml.includes('</Track>'));
+    ok(!xml.includes('<Trackpoint>'));
+  });
+
+  it('lap stats fields present when stat keys exist', () => {
+    const stats = { 'act-1': { Duration: 3600, Distance: 10000, Energy: 500 } };
+    const xml = buildTcx(baseEvent, [baseActivity], stats, { 'act-1': {} });
+    ok(xml.includes('<TotalTimeSeconds>3600</TotalTimeSeconds>'));
+    ok(xml.includes('<DistanceMeters>10000</DistanceMeters>'));
+    ok(xml.includes('<Calories>500</Calories>'));
+  });
+
+  it('lap stats fields omitted when absent', () => {
+    const xml = buildTcx(baseEvent, [baseActivity], { 'act-1': {} }, { 'act-1': {} });
+    ok(!xml.includes('<TotalTimeSeconds>'));
+    ok(!xml.includes('<Calories>'));
+    ok(!xml.includes('<MaximumSpeed>'));
+  });
+
+  it('trackpoint contains Position when Latitude+Longitude streams present', () => {
+    const streams = {
+      'act-1': {
+        Latitude: [{ time: 1700000000000, value: 51.5 }],
+        Longitude: [{ time: 1700000000000, value: -0.1 }],
+      },
+    };
+    const xml = buildTcx(baseEvent, [baseActivity], {}, streams);
+    ok(xml.includes('<Position>'));
+    ok(xml.includes('<LatitudeDegrees>51.5</LatitudeDegrees>'));
+    ok(xml.includes('<LongitudeDegrees>-0.1</LongitudeDegrees>'));
+  });
+
+  it('trackpoint handles Position stream as [lat, lon] array', () => {
+    const streams = {
+      'act-1': {
+        Position: [{ time: 1700000000000, value: [51.5, -0.1] }],
+      },
+    };
+    const xml = buildTcx(baseEvent, [baseActivity], {}, streams);
+    ok(xml.includes('<Position>'));
+    ok(xml.includes('<LatitudeDegrees>51.5</LatitudeDegrees>'));
+  });
+
+  it('trackpoint omits Position when no GPS streams', () => {
+    const streams = {
+      'act-1': { 'Heart Rate': [{ time: 1700000000000, value: 140 }] },
+    };
+    const xml = buildTcx(baseEvent, [baseActivity], {}, streams);
+    ok(!xml.includes('<Position>'));
+  });
+
+  it('Extensions block rendered when speed present, omitted when neither speed nor power', () => {
+    const withSpeed = {
+      'act-1': {
+        Speed: [{ time: 1700000000000, value: 3.0 }],
+        'Heart Rate': [{ time: 1700000000000, value: 140 }],
+      },
+    };
+    const withoutSpeedOrPower = {
+      'act-1': { 'Heart Rate': [{ time: 1700000000000, value: 140 }] },
+    };
+    ok(buildTcx(baseEvent, [baseActivity], {}, withSpeed).includes('<Extensions>'));
+    ok(!buildTcx(baseEvent, [baseActivity], {}, withoutSpeedOrPower).includes('<Extensions>'));
+  });
+
+  it('Extensions block not rendered when only Heart Rate is present', () => {
+    const streams = {
+      'act-1': { 'Heart Rate': [{ time: 1700000000000, value: 140 }] },
+    };
+    ok(!buildTcx(baseEvent, [baseActivity], {}, streams).includes('<Extensions>'));
+  });
+
+  it('multi-activity event produces multiple Lap elements', () => {
+    const act2 = {
+      id: 'act-2',
+      event_id: 'evt-1',
+      type: 'Cycling',
+      start_date: 1700001000000,
+      device_name: null,
+    };
+    const xml = buildTcx(baseEvent, [baseActivity, act2], {}, { 'act-1': {}, 'act-2': {} });
+    const lapCount = (xml.match(/<Lap /g) || []).length;
+    strictEqual(lapCount, 2);
+  });
+
+  it('Creator element rendered when device_name present', () => {
+    const actWithDevice = { ...baseActivity, device_name: 'Garmin Forerunner 945' };
+    const xml = buildTcx(baseEvent, [actWithDevice], {}, { 'act-1': {} });
+    ok(xml.includes('<Creator xsi:type="Device_t">'));
+    ok(xml.includes('<Name>Garmin Forerunner 945</Name>'));
+  });
+
+  it('Creator element omitted when device_name is null', () => {
+    const xml = buildTcx(baseEvent, [baseActivity], {}, { 'act-1': {} });
+    ok(!xml.includes('<Creator'));
+  });
+
+  it('uses event start_date for lap when activity start_date is null', () => {
+    const actNoDate = { ...baseActivity, start_date: null };
+    const xml = buildTcx(baseEvent, [actNoDate], {}, { 'act-1': {} });
+    const eventIso = new Date(1700000000000).toISOString();
+    ok(xml.includes(`StartTime="${eventIso}"`));
+  });
+});

--- a/backend/test/unit/utils/trackpoint-builder.test.js
+++ b/backend/test/unit/utils/trackpoint-builder.test.js
@@ -1,0 +1,142 @@
+const { describe, it } = require('node:test');
+const { strictEqual, deepStrictEqual, ok } = require('node:assert/strict');
+const {
+  buildUnifiedTimeline,
+  resolveValue,
+  buildTrackpoints,
+} = require('../../../src/utils/trackpoint-builder');
+
+describe('buildUnifiedTimeline', () => {
+  it('returns sorted union of all stream timestamps', () => {
+    const streamMap = {
+      'Heart Rate': [
+        { time: 3000, value: 120 },
+        { time: 1000, value: 100 },
+      ],
+      Distance: [
+        { time: 2000, value: 50 },
+        { time: 1000, value: 0 },
+      ],
+    };
+    deepStrictEqual(buildUnifiedTimeline(streamMap), [1000, 2000, 3000]);
+  });
+
+  it('returns empty array for empty streamMap', () => {
+    deepStrictEqual(buildUnifiedTimeline({}), []);
+  });
+
+  it('handles single stream correctly', () => {
+    const streamMap = {
+      HR: [
+        { time: 5000, value: 130 },
+        { time: 3000, value: 125 },
+      ],
+    };
+    deepStrictEqual(buildUnifiedTimeline(streamMap), [3000, 5000]);
+  });
+
+  it('handles streams with completely non-overlapping timestamps', () => {
+    const streamMap = {
+      A: [{ time: 1000, value: 1 }],
+      B: [{ time: 2000, value: 2 }],
+    };
+    deepStrictEqual(buildUnifiedTimeline(streamMap), [1000, 2000]);
+  });
+});
+
+describe('resolveValue', () => {
+  it('returns null for empty stream', () => {
+    strictEqual(resolveValue([], 1000), null);
+    strictEqual(resolveValue(null, 1000), null);
+  });
+
+  it('returns value for exact match', () => {
+    const stream = [
+      { time: 1000, value: 100 },
+      { time: 2000, value: 200 },
+    ];
+    strictEqual(resolveValue(stream, 1000), 100);
+    strictEqual(resolveValue(stream, 2000), 200);
+  });
+
+  it('returns nearest value within default tolerance', () => {
+    const stream = [
+      { time: 1000, value: 100 },
+      { time: 5000, value: 200 },
+    ];
+    // 1100ms is 100ms from 1000 vs 3900ms from 5000
+    strictEqual(resolveValue(stream, 1100), 100);
+  });
+
+  it('returns null when nearest is beyond default tolerance (30s)', () => {
+    const stream = [{ time: 1000, value: 100 }];
+    strictEqual(resolveValue(stream, 1000 + 31000), null);
+  });
+
+  it('returns value when nearest is exactly at tolerance boundary', () => {
+    const stream = [{ time: 1000, value: 100 }];
+    strictEqual(resolveValue(stream, 1000 + 30000), 100);
+  });
+
+  it('respects custom tolerance', () => {
+    const stream = [{ time: 1000, value: 100 }];
+    strictEqual(resolveValue(stream, 1000 + 5000, 3000), null);
+    strictEqual(resolveValue(stream, 1000 + 5000, 10000), 100);
+  });
+});
+
+describe('buildTrackpoints', () => {
+  it('returns empty array for empty streamMap', () => {
+    deepStrictEqual(buildTrackpoints({}), []);
+  });
+
+  it('produces one entry per unique timestamp', () => {
+    const streamMap = {
+      A: [{ time: 1000, value: 1 }],
+      B: [{ time: 2000, value: 2 }],
+    };
+    const result = buildTrackpoints(streamMap);
+    strictEqual(result.length, 2);
+    strictEqual(result[0].timeMs, 1000);
+    strictEqual(result[1].timeMs, 2000);
+  });
+
+  it('handles single stream correctly', () => {
+    const streamMap = {
+      Speed: [
+        { time: 1000, value: 5.5 },
+        { time: 2000, value: 6.0 },
+      ],
+    };
+    const result = buildTrackpoints(streamMap);
+    strictEqual(result.length, 2);
+    strictEqual(result[0].streams['Speed'], 5.5);
+    strictEqual(result[1].streams['Speed'], 6.0);
+  });
+
+  it('omits stream values beyond tolerance for non-overlapping timestamps', () => {
+    // Gap of 59s — beyond the 30s default tolerance
+    const streamMap = {
+      HR: [{ time: 1000, value: 100 }],
+      Distance: [{ time: 60000, value: 50 }],
+    };
+    const result = buildTrackpoints(streamMap);
+    strictEqual(result.length, 2);
+    ok('HR' in result[0].streams);
+    ok(!('Distance' in result[0].streams));
+    ok('Distance' in result[1].streams);
+    ok(!('HR' in result[1].streams));
+  });
+
+  it('includes stream values within tolerance at adjacent timestamps', () => {
+    // Gap of 5s — within the 30s default tolerance
+    const streamMap = {
+      HR: [{ time: 1000, value: 100 }],
+      Speed: [{ time: 6000, value: 3.5 }],
+    };
+    const result = buildTrackpoints(streamMap);
+    strictEqual(result.length, 2);
+    ok('HR' in result[0].streams);
+    ok('Speed' in result[0].streams); // 5s away — within tolerance
+  });
+});

--- a/docs/PRD.md
+++ b/docs/PRD.md
@@ -188,7 +188,27 @@ Some form of reporting on site activity (e.g. number of users, events, activitie
 
 **Status:** Planned
 
-Users may be able to export activity data back to standard file formats. The most likely direction is TCX export reconstructed from stored event and stream data, with an optional GPX route export for events that include GPS streams.
+Users can download activity data reconstructed from stored event, activity, stats, and stream data. The original uploaded file is discarded after processing and is not available for download; exports are a best-effort reconstruction from what was stored.
+
+Requirements:
+
+- provide a TCX export for every event, containing all stored stream data (heart rate, cadence, speed, power, altitude, distance, temperature, and GPS position where available)
+- provide a GPX export only when the event contains GPS streams (Latitude + Longitude or Position); includes route, elevation, and all supported extensions (heart rate, cadence, power, temperature)
+- multi-activity events produce a single file: one `<Lap>` per activity in TCX, one `<trkseg>` per activity in GPX
+- sport type is mapped from the stored activity type to the appropriate TCX or GPX value
+- device name is included in the TCX `<Creator>` element where stored
+- activity stats (total time, distance, max speed, calories, average and max heart rate) populate the TCX lap summary fields
+- trackpoints are built from the union of all stream timestamps; each stream value is resolved by nearest-neighbour lookup for that timestamp
+- exported files are named after the event name
+- the UI makes clear that exports are reconstructed from stored data and the original file was not retained; this notice is always visible near the export controls, not a modal blocker
+- export controls appear in the event detail view, top-right, at the same level as the "Back to Workouts" button, as a dropdown offering the available formats
+- the GPX option in the dropdown is only shown when the event has GPS streams
+- FIT export was considered and deferred: no viable Node.js FIT write library exists at the time of writing; the format's binary complexity and scale/offset requirements make a correct implementation impractical without a quality maintained library
+
+API:
+
+- `GET /api/events/:id/export/tcx` — returns a TCX file download; 404 if event is not found or not owned
+- `GET /api/events/:id/export/gpx` — returns a GPX file download; 404 if event is not found, not owned, or has no GPS streams
 
 ### 3.10 Third-party platform import
 

--- a/frontend/src/lib/api/__tests__/export.test.ts
+++ b/frontend/src/lib/api/__tests__/export.test.ts
@@ -1,0 +1,92 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { downloadEventTcx, downloadEventGpx } from '../export';
+
+beforeEach(() => {
+  vi.restoreAllMocks();
+});
+
+function mockFetchOk(contentType = 'application/xml') {
+  const blob = new Blob(['<xml/>'], { type: contentType });
+  return vi.fn().mockResolvedValue({
+    ok: true,
+    blob: () => Promise.resolve(blob),
+  });
+}
+
+function mockFetchFail(status = 404, statusText = 'Not Found') {
+  return vi.fn().mockResolvedValue({ ok: false, status, statusText });
+}
+
+describe('downloadEventTcx', () => {
+  it('calls apiFetch with correct TCX URL', async () => {
+    const mockFetch = mockFetchOk();
+    vi.stubGlobal('fetch', mockFetch);
+
+    const mockCreateObjectURL = vi.fn().mockReturnValue('blob:url');
+    const mockRevokeObjectURL = vi.fn();
+    vi.stubGlobal('URL', {
+      createObjectURL: mockCreateObjectURL,
+      revokeObjectURL: mockRevokeObjectURL,
+    });
+
+    const mockAnchor = {
+      href: '',
+      download: '',
+      style: { display: '' },
+      click: vi.fn(),
+      remove: vi.fn(),
+    };
+    vi.spyOn(document, 'createElement').mockReturnValue(mockAnchor as unknown as HTMLElement);
+    vi.spyOn(document.body, 'appendChild').mockImplementation(() => mockAnchor as unknown as Node);
+
+    await downloadEventTcx('evt-1', 'Morning Run');
+
+    expect(mockFetch).toHaveBeenCalledWith('/api/events/evt-1/export/tcx', expect.any(Object));
+    expect(mockAnchor.download).toBe('Morning Run.tcx');
+    expect(mockAnchor.click).toHaveBeenCalledOnce();
+    expect(mockRevokeObjectURL).toHaveBeenCalledWith('blob:url');
+  });
+
+  it('throws when response is not ok', async () => {
+    vi.stubGlobal('fetch', mockFetchFail(404, 'Not Found'));
+
+    await expect(downloadEventTcx('evt-1', 'run')).rejects.toThrow('TCX export failed: Not Found');
+  });
+});
+
+describe('downloadEventGpx', () => {
+  it('calls apiFetch with correct GPX URL', async () => {
+    const mockFetch = mockFetchOk('application/gpx+xml');
+    vi.stubGlobal('fetch', mockFetch);
+
+    const mockCreateObjectURL = vi.fn().mockReturnValue('blob:url');
+    const mockRevokeObjectURL = vi.fn();
+    vi.stubGlobal('URL', {
+      createObjectURL: mockCreateObjectURL,
+      revokeObjectURL: mockRevokeObjectURL,
+    });
+
+    const mockAnchor = {
+      href: '',
+      download: '',
+      style: { display: '' },
+      click: vi.fn(),
+      remove: vi.fn(),
+    };
+    vi.spyOn(document, 'createElement').mockReturnValue(mockAnchor as unknown as HTMLElement);
+    vi.spyOn(document.body, 'appendChild').mockImplementation(() => mockAnchor as unknown as Node);
+
+    await downloadEventGpx('evt-1', 'Morning Ride');
+
+    expect(mockFetch).toHaveBeenCalledWith('/api/events/evt-1/export/gpx', expect.any(Object));
+    expect(mockAnchor.download).toBe('Morning Ride.gpx');
+    expect(mockAnchor.click).toHaveBeenCalledOnce();
+    expect(mockRevokeObjectURL).toHaveBeenCalledWith('blob:url');
+  });
+
+  it('throws when response is not ok', async () => {
+    vi.stubGlobal('fetch', mockFetchFail(404, 'Not Found'));
+
+    await expect(downloadEventGpx('evt-1', 'ride')).rejects.toThrow('GPX export failed: Not Found');
+  });
+});

--- a/frontend/src/lib/api/export.ts
+++ b/frontend/src/lib/api/export.ts
@@ -1,0 +1,27 @@
+import { apiFetch } from './client';
+
+function triggerDownload(blob: Blob, filename: string): void {
+  const url = URL.createObjectURL(blob);
+  const a = document.createElement('a');
+  a.href = url;
+  a.download = filename;
+  a.style.display = 'none';
+  document.body.appendChild(a);
+  a.click();
+  a.remove();
+  URL.revokeObjectURL(url);
+}
+
+export async function downloadEventTcx(eventId: string, filename: string): Promise<void> {
+  const res = await apiFetch(`/api/events/${eventId}/export/tcx`);
+  if (!res.ok) throw new Error(`TCX export failed: ${res.statusText}`);
+  const blob = await res.blob();
+  triggerDownload(blob, `${filename}.tcx`);
+}
+
+export async function downloadEventGpx(eventId: string, filename: string): Promise<void> {
+  const res = await apiFetch(`/api/events/${eventId}/export/gpx`);
+  if (!res.ok) throw new Error(`GPX export failed: ${res.statusText}`);
+  const blob = await res.blob();
+  triggerDownload(blob, `${filename}.gpx`);
+}

--- a/frontend/src/lib/components/EventExportDropdown.svelte
+++ b/frontend/src/lib/components/EventExportDropdown.svelte
@@ -1,0 +1,92 @@
+<script lang="ts">
+  import { downloadEventTcx, downloadEventGpx } from '../api/export';
+
+  interface Props {
+    eventId: string;
+    eventName: string;
+    hasGps: boolean;
+  }
+  let { eventId, eventName, hasGps }: Props = $props();
+
+  let open = $state(false);
+  let downloading = $state<'tcx' | 'gpx' | null>(null);
+  let error = $state<string | null>(null);
+
+  function toggle() {
+    open = !open;
+  }
+
+  async function handleDownload(format: 'tcx' | 'gpx') {
+    if (downloading) return;
+    downloading = format;
+    error = null;
+    open = false;
+    try {
+      if (format === 'tcx') {
+        await downloadEventTcx(eventId, eventName);
+      } else {
+        await downloadEventGpx(eventId, eventName);
+      }
+    } catch (e) {
+      error = e instanceof Error ? e.message : 'Export failed';
+    } finally {
+      downloading = null;
+    }
+  }
+
+  function handleKeydown(e: KeyboardEvent) {
+    if (e.key === 'Escape') open = false;
+  }
+</script>
+
+<!-- svelte-ignore a11y_no_static_element_interactions -->
+<div class="relative" data-export-exclude onkeydown={handleKeydown}>
+  <button
+    type="button"
+    onclick={toggle}
+    disabled={downloading !== null}
+    class="inline-flex h-9 items-center gap-1.5 rounded border border-border bg-card px-3 text-sm text-text-secondary transition-colors hover:bg-card-hover hover:text-text-primary disabled:cursor-not-allowed disabled:opacity-50"
+  >
+    <span class="material-icons text-base" aria-hidden="true">
+      {downloading !== null ? 'hourglass_empty' : 'download'}
+    </span>
+    Export
+    <span class="material-icons text-sm" aria-hidden="true">expand_more</span>
+  </button>
+
+  {#if open}
+    <div
+      class="absolute right-0 top-full z-10 mt-1 min-w-[200px] rounded-md border border-border bg-card shadow-lg backdrop-blur-lg"
+    >
+      <div class="py-1">
+        <button
+          type="button"
+          class="flex w-full items-center gap-2 px-4 py-2 text-sm text-text-primary hover:bg-card-hover"
+          onclick={() => handleDownload('tcx')}
+        >
+          <span class="material-icons text-base" aria-hidden="true">download</span>
+          Download TCX
+        </button>
+        {#if hasGps}
+          <button
+            type="button"
+            class="flex w-full items-center gap-2 px-4 py-2 text-sm text-text-primary hover:bg-card-hover"
+            onclick={() => handleDownload('gpx')}
+          >
+            <span class="material-icons text-base" aria-hidden="true">download</span>
+            Download GPX
+          </button>
+        {/if}
+      </div>
+      <div class="border-t border-border px-4 py-2">
+        <p class="text-xs italic text-text-secondary">
+          Reconstructed from stored data — original file not retained
+        </p>
+      </div>
+    </div>
+  {/if}
+
+  {#if error}
+    <p class="mt-1 text-xs text-danger">{error}</p>
+  {/if}
+</div>

--- a/frontend/src/lib/components/__tests__/EventExportDropdown.test.ts
+++ b/frontend/src/lib/components/__tests__/EventExportDropdown.test.ts
@@ -1,0 +1,106 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent, waitFor } from '@testing-library/svelte';
+import EventExportDropdown from '../EventExportDropdown.svelte';
+
+const mockDownloadEventTcx = vi.fn();
+const mockDownloadEventGpx = vi.fn();
+
+vi.mock('../../api/export', () => ({
+  downloadEventTcx: (...args: unknown[]) => mockDownloadEventTcx(...args),
+  downloadEventGpx: (...args: unknown[]) => mockDownloadEventGpx(...args),
+}));
+
+const defaultProps = {
+  eventId: 'evt-1',
+  eventName: 'Morning Run',
+  hasGps: true,
+};
+
+beforeEach(() => {
+  mockDownloadEventTcx.mockReset().mockResolvedValue(undefined);
+  mockDownloadEventGpx.mockReset().mockResolvedValue(undefined);
+});
+
+describe('EventExportDropdown', () => {
+  it('renders Export button', () => {
+    render(EventExportDropdown, { props: defaultProps });
+    expect(screen.getByRole('button', { name: /Export/i })).toBeInTheDocument();
+  });
+
+  it('clicking button opens the dropdown', async () => {
+    render(EventExportDropdown, { props: defaultProps });
+    const button = screen.getByRole('button', { name: /Export/i });
+
+    expect(screen.queryByText('Download TCX')).not.toBeInTheDocument();
+    await fireEvent.click(button);
+    expect(screen.getByText('Download TCX')).toBeInTheDocument();
+  });
+
+  it('"Download TCX" item always rendered when dropdown is open', async () => {
+    render(EventExportDropdown, { props: { ...defaultProps, hasGps: false } });
+    await fireEvent.click(screen.getByRole('button', { name: /Export/i }));
+    expect(screen.getByText('Download TCX')).toBeInTheDocument();
+  });
+
+  it('"Download GPX" item rendered when hasGps=true', async () => {
+    render(EventExportDropdown, { props: { ...defaultProps, hasGps: true } });
+    await fireEvent.click(screen.getByRole('button', { name: /Export/i }));
+    expect(screen.getByText('Download GPX')).toBeInTheDocument();
+  });
+
+  it('"Download GPX" item not rendered when hasGps=false', async () => {
+    render(EventExportDropdown, { props: { ...defaultProps, hasGps: false } });
+    await fireEvent.click(screen.getByRole('button', { name: /Export/i }));
+    expect(screen.queryByText('Download GPX')).not.toBeInTheDocument();
+  });
+
+  it('clicking "Download TCX" calls downloadEventTcx with correct args', async () => {
+    render(EventExportDropdown, { props: defaultProps });
+    await fireEvent.click(screen.getByRole('button', { name: /Export/i }));
+    await fireEvent.click(screen.getByText('Download TCX'));
+    expect(mockDownloadEventTcx).toHaveBeenCalledWith('evt-1', 'Morning Run');
+  });
+
+  it('clicking "Download GPX" calls downloadEventGpx with correct args', async () => {
+    render(EventExportDropdown, { props: defaultProps });
+    await fireEvent.click(screen.getByRole('button', { name: /Export/i }));
+    await fireEvent.click(screen.getByText('Download GPX'));
+    expect(mockDownloadEventGpx).toHaveBeenCalledWith('evt-1', 'Morning Run');
+  });
+
+  it('shows error message when download throws', async () => {
+    mockDownloadEventTcx.mockRejectedValue(new Error('TCX export failed: Not Found'));
+    render(EventExportDropdown, { props: defaultProps });
+    await fireEvent.click(screen.getByRole('button', { name: /Export/i }));
+    await fireEvent.click(screen.getByText('Download TCX'));
+    await waitFor(() => {
+      expect(screen.getByText('TCX export failed: Not Found')).toBeInTheDocument();
+    });
+  });
+
+  it('dropdown closes after selecting an item', async () => {
+    render(EventExportDropdown, { props: defaultProps });
+    await fireEvent.click(screen.getByRole('button', { name: /Export/i }));
+    expect(screen.getByText('Download TCX')).toBeInTheDocument();
+    await fireEvent.click(screen.getByText('Download TCX'));
+    // Dropdown should be closed (Download TCX no longer in DOM)
+    await waitFor(() => {
+      expect(screen.queryByText('Download TCX')).not.toBeInTheDocument();
+    });
+  });
+
+  it('Escape key closes the dropdown', async () => {
+    const { container } = render(EventExportDropdown, { props: defaultProps });
+    await fireEvent.click(screen.getByRole('button', { name: /Export/i }));
+    expect(screen.getByText('Download TCX')).toBeInTheDocument();
+
+    const wrapper = container.querySelector('[data-export-exclude]') as HTMLElement;
+    await fireEvent.keyDown(wrapper, { key: 'Escape' });
+    expect(screen.queryByText('Download TCX')).not.toBeInTheDocument();
+  });
+
+  it('has data-export-exclude attribute so PNG export ignores it', () => {
+    const { container } = render(EventExportDropdown, { props: defaultProps });
+    expect(container.querySelector('[data-export-exclude]')).toBeInTheDocument();
+  });
+});

--- a/frontend/src/lib/components/workouts/CompareCandidatesFlow.svelte
+++ b/frontend/src/lib/components/workouts/CompareCandidatesFlow.svelte
@@ -15,7 +15,7 @@
   let candidates = $state<EventSummary[]>([]);
   let candidatesLoading = $state(false);
   let selectedCandidateIds = $state<Set<string>>(new Set());
-  let showAllFolders = $state(false);
+  let showAllFolders = $state(true);
 
   const sourceEventRow = $derived.by(() => {
     if (!sourceEventId) return null;
@@ -43,7 +43,7 @@
 
   export function openForEvent(eventId: string) {
     sourceEventId = eventId;
-    showAllFolders = false;
+    showAllFolders = true;
     void loadCandidates(eventId);
   }
 

--- a/frontend/src/lib/components/workouts/CompareCandidatesModal.svelte
+++ b/frontend/src/lib/components/workouts/CompareCandidatesModal.svelte
@@ -107,6 +107,17 @@
       </div>
 
       <div class="flex-1 overflow-y-auto p-6">
+        {#if onToggleShowAllFolders}
+          <p class="mb-4">
+            <button
+              type="button"
+              class="text-sm font-medium text-accent hover:underline"
+              onclick={onToggleShowAllFolders}
+            >
+              {showAllFolders ? 'Same folder only' : 'Show all folders'}
+            </button>
+          </p>
+        {/if}
         {#if candidatesLoading}
           <div class="flex justify-center py-8">
             <LoadingSpinner />
@@ -119,17 +130,6 @@
           <p class="mb-2 text-sm text-text-secondary">
             Select events that overlap in time with this event to compare:
           </p>
-          {#if onToggleShowAllFolders}
-            <p class="mb-4">
-              <button
-                type="button"
-                class="text-sm font-medium text-accent hover:underline"
-                onclick={onToggleShowAllFolders}
-              >
-                {showAllFolders ? 'Same folder only' : 'Show all folders'}
-              </button>
-            </p>
-          {/if}
           <div class="space-y-2">
             {#each candidates as candidate (candidate.id)}
               {@const isSelected = selectedCandidateIds.has(candidate.id)}

--- a/frontend/src/routes/__tests__/workouts.test.ts
+++ b/frontend/src/routes/__tests__/workouts.test.ts
@@ -470,7 +470,7 @@ describe('Workouts', () => {
     await fireEvent.click(findButton);
     await waitFor(() => {
       expect(mockGetComparisonCandidates).toHaveBeenCalledWith('evt-1', {
-        sameFolderOnly: true,
+        sameFolderOnly: false,
       });
     });
   });

--- a/frontend/src/routes/event-detail.svelte
+++ b/frontend/src/routes/event-detail.svelte
@@ -31,6 +31,7 @@
   import EventDetailStreamCharts from '../lib/components/event-detail/EventDetailStreamCharts.svelte';
   import PowerCurveChart from '../lib/components/event-detail/PowerCurveChart.svelte';
   import ExportButton from '../lib/components/ExportButton.svelte';
+  import EventExportDropdown from '../lib/components/EventExportDropdown.svelte';
   import { exportAsPng } from '../lib/utils/export-image';
   import { buildFolderHash } from '../lib/stores/folders.svelte';
   import CompareCandidatesFlow from '../lib/components/workouts/CompareCandidatesFlow.svelte';
@@ -436,13 +437,22 @@
 </script>
 
 <section class="mx-auto w-[85%] max-w-screen-2xl py-6">
-  <button
-    type="button"
-    class="mb-4 rounded border border-border px-3 py-1.5 text-base text-text-secondary hover:bg-card-hover hover:text-text-primary"
-    onclick={() => push(backPath)}
-  >
-    ← Back to Workouts
-  </button>
+  <div class="mb-4 flex items-center justify-between">
+    <button
+      type="button"
+      class="rounded border border-border px-3 py-1.5 text-base text-text-secondary hover:bg-card-hover hover:text-text-primary"
+      onclick={() => push(backPath)}
+    >
+      ← Back to Workouts
+    </button>
+    {#if event}
+      <EventExportDropdown
+        eventId={id}
+        eventName={event.name ?? 'event'}
+        hasGps={locationAvailable}
+      />
+    {/if}
+  </div>
 
   {#if loading}
     <div class="flex justify-center py-12">


### PR DESCRIPTION
**Changes:**
 * Add TCX and GPX export endpoints (GET /api/events/:id/export/tcx|gpx)
 * Add export-service, tcx-builder, gpx-builder, trackpoint-builder utilities and tests
 * Add EventExportDropdown frontend component and export API module
 * Expose export buttons on event-detail page
 * Fix TCX export missing calories: stats key is 'Energy' (DataEnergy), not 'Calories'
 * Fix comparison candidates defaulting to same-folder-only, blocking cross-folder matches
 * Show folder toggle in comparison modal even when no candidates are found