### PR TITLE
feat: drag-and-drop workouts into sidebar folders

### DIFF
--- a/frontend/src/App.svelte
+++ b/frontend/src/App.svelte
@@ -23,6 +23,8 @@
   import { FOLDER_SELECTION_ALL, FOLDER_SELECTION_UNFILED } from './lib/types/event';
   import type { Folder } from './lib/types/event';
   import { updateFolder } from './lib/api/folders';
+  import { updateEventFolder } from './lib/api/events';
+  import { workoutDragState, endWorkoutDrag } from './lib/stores/workout-drag.svelte';
   import logoIcon from './assets/logo-icon.svg';
   import logoBig from './assets/logo-big.svg';
   import FolderCreateModal from './lib/components/folders/FolderCreateModal.svelte';
@@ -145,18 +147,56 @@
   });
 
   const sidebarWidth = $derived(sidebarCollapsed ? '4rem' : '16rem');
+  const sidebarEffectivelyExpanded = $derived(!sidebarCollapsed || workoutDragState.isDragging);
+
+  let dragOverFolderId = $state<string | null>(null);
+
+  $effect(() => {
+    const onDragEnd = () => endWorkoutDrag();
+    window.addEventListener('dragend', onDragEnd);
+    return () => window.removeEventListener('dragend', onDragEnd);
+  });
+
+  async function handleWorkoutFolderDrop(e: DragEvent, targetFolderId: string | null) {
+    e.preventDefault();
+    dragOverFolderId = null;
+    endWorkoutDrag();
+    const data = e.dataTransfer?.getData('application/x-openfitlab-workout-ids');
+    if (!data) return;
+    const eventIds: string[] = JSON.parse(data);
+    let successCount = 0;
+    let failCount = 0;
+    for (const id of eventIds) {
+      try {
+        await updateEventFolder(id, targetFolderId);
+        successCount++;
+      } catch {
+        failCount++;
+      }
+    }
+    const label = targetFolderId
+      ? (foldersState.folders.find((f) => f.id === targetFolderId)?.name ?? 'folder')
+      : 'Unfiled';
+    showFolderToast(
+      failCount > 0
+        ? `Moved ${successCount}, failed ${failCount}`
+        : `Moved ${successCount} workout${successCount !== 1 ? 's' : ''} to ${label}`
+    );
+    loadFolders();
+    window.dispatchEvent(new CustomEvent('workout-moved'));
+  }
 </script>
 
 <div class="min-h-screen flex">
   <!-- Sidebar -->
   <nav
     class="fixed left-0 top-0 z-50 h-screen border-r border-border bg-surface backdrop-blur-xl transition-all duration-300"
-    style="width: {sidebarWidth};"
+    style="width: {sidebarEffectivelyExpanded ? '16rem' : '4rem'};"
   >
     <div class="flex h-full flex-col">
       <!-- Logo/Branding -->
       <div class="flex items-center border-b border-border px-4 py-4">
-        {#if sidebarCollapsed}
+        {#if !sidebarEffectivelyExpanded}
           <img src={logoIcon} alt="OpenFitLab" class="h-16" />
         {:else}
           <img src={logoBig} alt="OpenFitLab" class="h-16" />
@@ -181,11 +221,11 @@
                 : ''}"
             >
               <span class="material-icons">dashboard</span>
-              {#if !sidebarCollapsed}
+              {#if sidebarEffectivelyExpanded}
                 <span>Workouts</span>
               {/if}
             </a>
-            {#if !sidebarCollapsed}
+            {#if sidebarEffectivelyExpanded}
               <button
                 bind:this={newFolderBtnEl}
                 type="button"
@@ -197,7 +237,7 @@
               </button>
             {/if}
           </div>
-          {#if !sidebarCollapsed}
+          {#if sidebarEffectivelyExpanded}
             <div class="mt-1 pl-11">
               <div class="flex items-center gap-0.5 py-0.5">
                 <a
@@ -215,7 +255,20 @@
                   <span>All</span>
                 </a>
               </div>
-              <div class="flex items-center gap-0.5 py-0.5">
+              <div
+                class="flex items-center gap-0.5 py-0.5 rounded {dragOverFolderId === '__unfiled__'
+                  ? 'bg-card-hover ring-1 ring-accent'
+                  : ''}"
+                ondragover={(e) => {
+                  if (!workoutDragState.isDragging) return;
+                  e.preventDefault();
+                  dragOverFolderId = '__unfiled__';
+                }}
+                ondragleave={() => {
+                  dragOverFolderId = null;
+                }}
+                ondrop={(e) => handleWorkoutFolderDrop(e, null)}
+              >
                 <a
                   href={buildFolderHash(FOLDER_SELECTION_UNFILED)}
                   class="flex min-w-0 flex-1 items-center gap-2 py-2 pr-0 text-sm text-text-secondary transition-colors hover:text-text-primary {isWorkoutsActive &&
@@ -232,7 +285,20 @@
                 </a>
               </div>
               {#each pinnedFolders as folder (folder.id)}
-                <div class="flex items-center gap-0.5 py-0.5">
+                <div
+                  class="flex items-center gap-0.5 py-0.5 rounded {dragOverFolderId === folder.id
+                    ? 'bg-card-hover ring-1 ring-accent'
+                    : ''}"
+                  ondragover={(e) => {
+                    if (!workoutDragState.isDragging) return;
+                    e.preventDefault();
+                    dragOverFolderId = folder.id;
+                  }}
+                  ondragleave={() => {
+                    dragOverFolderId = null;
+                  }}
+                  ondrop={(e) => handleWorkoutFolderDrop(e, folder.id)}
+                >
                   <a
                     href={buildFolderHash(folder.id)}
                     class="flex min-w-0 flex-1 items-center gap-2 py-2 pr-0 text-sm text-text-secondary transition-colors hover:text-text-primary {isWorkoutsActive &&
@@ -270,7 +336,20 @@
                 </div>
               {/each}
               {#each unpinnedFolders as folder (folder.id)}
-                <div class="flex items-center gap-0.5 py-0.5">
+                <div
+                  class="flex items-center gap-0.5 py-0.5 rounded {dragOverFolderId === folder.id
+                    ? 'bg-card-hover ring-1 ring-accent'
+                    : ''}"
+                  ondragover={(e) => {
+                    if (!workoutDragState.isDragging) return;
+                    e.preventDefault();
+                    dragOverFolderId = folder.id;
+                  }}
+                  ondragleave={() => {
+                    dragOverFolderId = null;
+                  }}
+                  ondrop={(e) => handleWorkoutFolderDrop(e, folder.id)}
+                >
                   <a
                     href={buildFolderHash(folder.id)}
                     class="flex min-w-0 flex-1 items-center gap-2 py-2 pr-0 text-sm text-text-secondary transition-colors hover:text-text-primary {isWorkoutsActive &&
@@ -313,7 +392,7 @@
               : ''}"
           >
             <span class="material-icons">compare_arrows</span>
-            {#if !sidebarCollapsed}
+            {#if sidebarEffectivelyExpanded}
               <span>Comparisons</span>
             {/if}
           </a>
@@ -426,8 +505,10 @@
           onclick={toggleSidebar}
           aria-label={sidebarCollapsed ? 'Expand sidebar' : 'Collapse sidebar'}
         >
-          <span class="material-icons">{sidebarCollapsed ? 'chevron_right' : 'chevron_left'}</span>
-          {#if !sidebarCollapsed}
+          <span class="material-icons"
+            >{sidebarEffectivelyExpanded ? 'chevron_left' : 'chevron_right'}</span
+          >
+          {#if sidebarEffectivelyExpanded}
             <span>Collapse</span>
           {/if}
         </button>

--- a/frontend/src/lib/components/workouts/WorkoutsActivityTable.svelte
+++ b/frontend/src/lib/components/workouts/WorkoutsActivityTable.svelte
@@ -25,6 +25,8 @@
     onFindComparisonsClick: (eventId: string) => void;
     onMoveClick: (eventId: string, e: MouseEvent) => void;
     onDeleteClick: (eventId: string, e: MouseEvent) => void;
+    onDragStart?: (row: ActivityRow, e: DragEvent) => void;
+    onDragEnd?: () => void;
   }
   let {
     rows,
@@ -45,7 +47,11 @@
     onFindComparisonsClick,
     onMoveClick,
     onDeleteClick,
+    onDragStart,
+    onDragEnd,
   }: Props = $props();
+
+  let draggingEventId = $state<string | null>(null);
 </script>
 
 <div class="overflow-hidden rounded-lg border border-border bg-card shadow backdrop-blur-lg">
@@ -116,9 +122,11 @@
           <tr
             role="link"
             tabindex="0"
+            draggable="true"
             class="hover:bg-card-hover"
             class:cursor-pointer={!isLoading}
             class:bg-card-hover={isSelected}
+            class:opacity-50={draggingEventId === row.event.id}
             onclick={() => {
               if (!isLoading) onRowClick(row.event.id);
             }}
@@ -127,6 +135,14 @@
                 e.preventDefault();
                 onRowClick(row.event.id);
               }
+            }}
+            ondragstart={(e) => {
+              draggingEventId = row.event.id;
+              onDragStart?.(row, e);
+            }}
+            ondragend={() => {
+              draggingEventId = null;
+              onDragEnd?.();
             }}
           >
             <td class="px-3 py-4" onclick={(e) => e.stopPropagation()}>

--- a/frontend/src/lib/stores/__tests__/workout-drag.test.ts
+++ b/frontend/src/lib/stores/__tests__/workout-drag.test.ts
@@ -1,0 +1,37 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { workoutDragState, startWorkoutDrag, endWorkoutDrag } from '../workout-drag.svelte';
+
+beforeEach(() => {
+  workoutDragState.isDragging = false;
+  workoutDragState.eventIds = [];
+});
+
+describe('startWorkoutDrag', () => {
+  it('sets isDragging to true and stores event IDs', () => {
+    startWorkoutDrag(['id-1', 'id-2']);
+    expect(workoutDragState.isDragging).toBe(true);
+    expect(workoutDragState.eventIds).toEqual(['id-1', 'id-2']);
+  });
+
+  it('overwrites previous drag IDs on a second call', () => {
+    startWorkoutDrag(['id-1']);
+    startWorkoutDrag(['id-2', 'id-3']);
+    expect(workoutDragState.eventIds).toEqual(['id-2', 'id-3']);
+  });
+});
+
+describe('endWorkoutDrag', () => {
+  it('resets isDragging and clears eventIds', () => {
+    startWorkoutDrag(['id-1']);
+    endWorkoutDrag();
+    expect(workoutDragState.isDragging).toBe(false);
+    expect(workoutDragState.eventIds).toEqual([]);
+  });
+
+  it('is idempotent when called multiple times', () => {
+    endWorkoutDrag();
+    endWorkoutDrag();
+    expect(workoutDragState.isDragging).toBe(false);
+    expect(workoutDragState.eventIds).toEqual([]);
+  });
+});

--- a/frontend/src/lib/stores/workout-drag.svelte.ts
+++ b/frontend/src/lib/stores/workout-drag.svelte.ts
@@ -1,0 +1,14 @@
+export const workoutDragState = $state({
+  isDragging: false,
+  eventIds: [] as string[],
+});
+
+export function startWorkoutDrag(ids: string[]) {
+  workoutDragState.isDragging = true;
+  workoutDragState.eventIds = ids;
+}
+
+export function endWorkoutDrag() {
+  workoutDragState.isDragging = false;
+  workoutDragState.eventIds = [];
+}

--- a/frontend/src/routes/workouts.svelte
+++ b/frontend/src/routes/workouts.svelte
@@ -11,6 +11,7 @@
   } from '../lib/api';
   import type { ActivityRow } from '../lib/types';
   import { foldersState, getFolderFromHash } from '../lib/stores/folders.svelte';
+  import { startWorkoutDrag, endWorkoutDrag } from '../lib/stores/workout-drag.svelte';
   import { getEnvNumber } from '../lib/utils/env';
   import {
     formatDurationCell,
@@ -314,6 +315,26 @@
     selectedEventIds = new Set();
   }
 
+  function handleDragStart(row: ActivityRow, e: DragEvent) {
+    const idsToMove = selectedEventIds.has(row.event.id) ? [...selectedEventIds] : [row.event.id];
+    e.dataTransfer!.setData('application/x-openfitlab-workout-ids', JSON.stringify(idsToMove));
+    e.dataTransfer!.effectAllowed = 'move';
+    startWorkoutDrag(idsToMove);
+  }
+
+  function handleDragEnd() {
+    endWorkoutDrag();
+  }
+
+  $effect(() => {
+    const handler = () => {
+      selectedEventIds = new Set();
+      loadActivityRows();
+    };
+    window.addEventListener('workout-moved', handler);
+    return () => window.removeEventListener('workout-moved', handler);
+  });
+
   function handleBulkDeleteClick() {
     const eventIds = Array.from(selectedEventIds);
     if (eventIds.length === 0) return;
@@ -468,6 +489,8 @@
           eventIdsToMove = [id];
         }}
         onDeleteClick={handleDeleteClick}
+        onDragStart={handleDragStart}
+        onDragEnd={handleDragEnd}
       />
     </WorkoutsPaginationWithUrl>
 


### PR DESCRIPTION
**Changes:**
 * Add workout-drag store to track drag state (isDragging, eventIds)
 * Make WorkoutsActivityTable rows draggable with onDragStart/onDragEnd callbacks
 * Wire drag start to carry selected event IDs (or single row) via dataTransfer
 * Expand sidebar automatically while dragging so folder targets are visible
 * Add drop zones on Unfiled, pinned, and unpinned sidebar folder entries
 * Handle drop in App.svelte: update folder for each dragged event, show toast, reload
 * Add tests for workout-drag store