### PR TITLE
Documentation audit: accuracy, OpenAPI, deduplication, CSRF

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -67,18 +67,18 @@
 
 ## Agent-critical invariants
 
-- Authentication is server-side session auth with OAuth providers and a Valkey-backed session store. Do not introduce JWT or localStorage auth.
-- State-changing requests require the CSRF token returned by `GET /api/auth/me`.
-- All event, comparison, folder, and derived meta queries must be scoped by authenticated ownership using `req.userId`.
-- Return `404` for missing or not-owned resources by ID to avoid leaking existence.
-- Files are parsed on the backend (TCX, FIT, GPX, JSON, SML via `@sports-alliance/sports-lib`) and discarded. Do not store originals after upload.
-- Stats stay relational in `event_stats` and `activity_stats`. Do not collapse them into JSON blobs.
-- Stream points are stored as packed JSON arrays in `streams.data` (compressed). Each entry is `{ time, value }`.
-- Comparison membership stays relational in `comparison_event_activities`.
-- Deleting an event must remove comparisons that reference it before the event delete completes.
-- New foreign keys must use `ON DELETE CASCADE` unless there is a specific reason to unfile rather than delete (like `folder_id` which uses `SET NULL`).
-- Schema is managed by a lightweight migration runner (`db.runMigrations()`). Migration files live in `backend/sql/migrations/` (named `NNN_description.sql`, applied lexicographically). A `schema_migrations` table tracks applied files. A MariaDB advisory lock (`GET_LOCK`) prevents race conditions during rolling deploys. New schema changes require a new migration file — never edit existing ones. `backend/sql/schema.sql` is a human-readable reference snapshot only.
-- Backend configuration must come from `backend/src/config.js`, not direct `process.env` reads elsewhere.
+Rules below are the non-negotiables for agents changing code. **Schema shape, storage layout, migrations, deployment, and security details** are documented in [docs/ARCHITECTURE.md](docs/ARCHITECTURE.md) — read that for full context, not duplicated here.
+
+- Server-side sessions (OAuth + Valkey store). **No** JWT or localStorage auth.
+- State-changing requests need the CSRF token from `GET /api/auth/me`. Send it as **`CSRF-Token`** (SPA default) or **`x-csrf-token`** (also accepted; see [`backend/docs/openapi.yaml`](backend/docs/openapi.yaml)).
+- Scope all event, comparison, folder, and meta queries by authenticated ownership (`req.userId`).
+- **`404`** for missing or not-owned resources by ID (no existence leaks).
+- Parse files only on the backend; **no** retained originals after upload.
+- **Relational** stats (`event_stats`, `activity_stats`); **relational** comparison membership (`comparison_event_activities`); **packed** stream points in `streams.data`.
+- Event delete must clear comparisons that reference the event first (service workflow).
+- New FKs: `ON DELETE CASCADE` unless unfile semantics apply (`folder_id` → `SET NULL`).
+- **New migrations only** — never edit applied migration files; `backend/sql/schema.sql` is a snapshot.
+- Config only via [`backend/src/config.js`](backend/src/config.js).
 
 ## API contract
 
@@ -86,7 +86,7 @@ The full machine-readable API specification is at [`backend/docs/openapi.yaml`](
 
 Key points:
 - All protected endpoints require a valid session cookie (`ofl.sid`).
-- All state-changing requests (POST, PATCH, DELETE) must include the `CSRF-Token` header. Obtain it from `GET /api/auth/me`.
+- All state-changing requests (POST, PATCH, DELETE) must include the CSRF token in a header (**`CSRF-Token`** or **`x-csrf-token`**). Obtain the value from `GET /api/auth/me`.
 - Error responses are always `{ "error": "<message>" }`.
 - Missing or unowned resources return `404`, not `403`.
 - Response shapes for events and activities are produced by `mapEventRow` and `mapActivityRow` in `backend/src/utils/transforms.js` (imported Strava events include optional `importProvider` / `importExternalId`).

--- a/README.md
+++ b/README.md
@@ -26,45 +26,12 @@ A self-hosted fitness activity tracking and comparison platform. Upload activity
 
 ## Architecture
 
-```mermaid
-graph TB
-    User[User] --> Frontend[Svelte Frontend<br/>Port 4200]
-    Frontend --> API[Express API<br/>Port 3000]
-    API --> Parser[File Parser<br/>sports-lib]
-    API --> DB[(MariaDB<br/>Port 3306)]
-    Parser --> DB
-
-    subgraph "Data Flow"
-        Upload[Upload File] --> Parse[Parse File]
-        Parse --> Store[Store in DB]
-        Store --> Visualize[Visualize Data]
-    end
-```
-
-### Technology Stack
-
-- **Backend**: Node.js 24, Express.js, MariaDB
-- **Frontend**: Svelte 5, Vite, Tailwind CSS v4
-- **Parsing**: `@sports-alliance/sports-lib` for TCX/FIT/GPX/JSON/SML parsing
-- **Deployment**: Docker Compose (self-hosted)
-
-### Database Schema
-
-The application uses a relational database structure:
-
-- **Events**: Top-level workout sessions with metadata
-- **Event Stats**: Relational storage for event-level statistics (one row per stat type)
-- **Activities**: Individual activities within an event
-- **Activity Stats**: Relational storage for activity-level statistics
-- **Streams**: Stream metadata (heart rate, cadence, pace, etc.)
-- **Stream Data**: Packed JSON array of `{ time, value }` points stored in `streams.data` (compressed, ~30-50x size reduction)
-
-See [docs/ARCHITECTURE.md](docs/ARCHITECTURE.md) for detailed architecture documentation.
+High level: Svelte frontend → Express API → MariaDB; file parsing uses `@sports-alliance/sports-lib` on the API. See **[docs/ARCHITECTURE.md](docs/ARCHITECTURE.md)** for stack diagram, schema, API behaviour, and deployment.
 
 ## Prerequisites
 
 - Docker and Docker Compose
-- (Optional) Node 22 for frontend, Node 24 for backend if running outside Docker
+- (Optional) Node 20+ for frontend, Node 24+ for backend if running outside Docker (see [AGENTS.md](AGENTS.md))
 
 ## Quick Start
 
@@ -75,7 +42,7 @@ docker compose up -d
 ```
 
 This starts:
-- **DB:** MariaDB on `localhost:3306` (user/password/database from `.env` or defaults in `docker-compose.yaml`)
+- **DB:** MariaDB on `localhost:3306` (user/password/database from `.env` or defaults in `compose.yaml`)
 - **API:** http://localhost:3000 (GET `/` or `/health` returns `{ "ok": true }`)
 - **Frontend:** http://localhost:4200 (Svelte/Vite dev server)
 - **Adminer:** http://localhost:8080 (database admin UI)
@@ -91,13 +58,13 @@ Edit files under `backend/` or `frontend/` on your host and changes are reflecte
 
 ## Testing / Quality checks
 
-- **Backend:** From `backend/`: `npm run lint`, `npm run format`, `npm run test:unit`. See [AGENTS.md](AGENTS.md) for full commands.
+- **Backend:** From `backend/`: `npm run format`, `npm run lint`, `npm run test` (full suite). See [AGENTS.md](AGENTS.md) for coverage and CI alignment.
 - **Frontend:** From `frontend/`: `npm run ci` runs format, lint, typecheck, tests, and build.
 - **CI:** Push and pull requests to `main` run backend checks when backend files change and frontend checks when frontend files change (see `.github/workflows/`).
 
 ## API Documentation
 
-Events API: **GET** `/api/events` (list), **GET** `/api/events/:id` (single + activities), **GET** `/api/events/:id/activities/:activityId/streams` (streams), **POST** `/api/events` (upload), **DELETE** `/api/events/:id` (delete). See [docs/ARCHITECTURE.md](docs/ARCHITECTURE.md) for parameters and response shapes.
+Machine-readable contract: [`backend/docs/openapi.yaml`](backend/docs/openapi.yaml). Human-oriented route list and shapes: [docs/ARCHITECTURE.md](docs/ARCHITECTURE.md).
 
 ## Production Build
 
@@ -107,7 +74,7 @@ Build the frontend for production:
 cd frontend && npm run build
 ```
 
-Output is in `frontend/dist/`. The build uses `/api` as the API base URL (proxied in dev, same-origin in production). Deploy the `dist/` folder to any static host and ensure `/api` routes to the Node API. For cloud deployment (managed database, static frontend, serverless/small compute) on AWS or GCP, see the [hosting guide](docs/HOSTING.md).
+Output is in `frontend/dist/`. The build uses `/api` as the API base URL (proxied in dev, same-origin in production). Deploy the `dist/` folder to any static host and ensure `/api` routes to the Node API.
 
 ## Environment
 
@@ -145,7 +112,6 @@ Data in MariaDB is kept in the `db_data` volume. Use `docker compose down -v` to
 
 - **[AGENTS.md](AGENTS.md)** - AI coding agent context and instructions
 - **[docs/ARCHITECTURE.md](docs/ARCHITECTURE.md)** - Detailed system architecture
-- **[docs/HOSTING.md](docs/HOSTING.md)** - Cloud hosting guide (AWS and GCP, cost-effective options)
 - **[docs/INTEGRATIONS_INSTRUCTIONS.md](docs/INTEGRATIONS_INSTRUCTIONS.md)** - OAuth providers (Google, GitHub, Apple, Facebook) and Strava import setup
 - **[docs/PRD.md](docs/PRD.md)** - Product Requirements Document
 

--- a/backend/README.md
+++ b/backend/README.md
@@ -23,14 +23,7 @@ SQL in repositories only; services pass `opts.db` or `opts.conn` (inside transac
 
 ## Run locally
 
-```bash
-cd backend
-npm install
-# Set DB_* env if not using defaults (see AGENTS.md)
-npm run dev
-```
-
-API: http://localhost:3000. Health: GET `/health`.
+Install deps, configure `.env` (see root `.env.example` and [AGENTS.md](../AGENTS.md)), then `npm run dev` in this directory. API: `http://localhost:3000`; health: `GET /health`.
 
 ## Strava import (optional)
 

--- a/backend/docs/openapi.yaml
+++ b/backend/docs/openapi.yaml
@@ -6,11 +6,14 @@ info:
     REST API for the OpenFitLab self-hosted fitness activity tracker.
 
     **Authentication:** All protected endpoints require a valid session cookie
-    (`ofl.sid`). Obtain a session by completing the OAuth flow via
-    `GET /api/auth/google` or `GET /api/auth/github`.
+    (`ofl.sid`). Obtain a session by completing the OAuth flow via one of the
+    configured providers: `GET /api/auth/google`, `GET /api/auth/github`,
+    `GET /api/auth/apple`, or `GET /api/auth/facebook` (only providers with
+    credentials in the environment are usable).
 
     **CSRF:** All state-changing requests (POST, PATCH, DELETE) must include the
-    `x-csrf-token` header. Obtain the token from `GET /api/auth/me`.
+    token in a header: `CSRF-Token` (used by the web app) or `x-csrf-token`
+    (also accepted). Obtain the token from `GET /api/auth/me`.
 
     **Ownership:** All resource endpoints scope data to the authenticated user.
     A missing or unowned resource returns `404` (not `403`) to avoid leaking existence.
@@ -306,7 +309,7 @@ components:
           nullable: true
         csrfToken:
           type: string
-          description: CSRF token — include as x-csrf-token header on all state-changing requests
+          description: CSRF token — send as CSRF-Token or x-csrf-token on state-changing requests
         pendingSignup:
           type: boolean
           description: Present and true when the user has authenticated via OAuth but has not yet accepted terms
@@ -475,7 +478,9 @@ components:
       type: apiKey
       in: header
       name: x-csrf-token
-      description: CSRF token obtained from GET /api/auth/me. Required on all state-changing requests (POST, PATCH, DELETE).
+      description: |
+        CSRF token from GET /api/auth/me. Send as this header or as CSRF-Token
+        (both accepted). Required on state-changing requests (POST, PATCH, DELETE).
 
 # ---------------------------------------------------------------------------
 # Paths
@@ -541,6 +546,63 @@ paths:
       tags: [auth]
       summary: GitHub OAuth callback
       description: Handles the redirect from GitHub. Behaviour mirrors the Google callback.
+      responses:
+        "302":
+          description: Redirect to SPA
+
+  /api/auth/apple:
+    get:
+      tags: [auth]
+      summary: Initiate Apple Sign In flow
+      description: Redirects to Apple. Returns 400 if Apple OAuth is not configured.
+      responses:
+        "302":
+          description: Redirect to Apple authorization endpoint
+        "400":
+          $ref: "#/components/responses/BadRequest"
+
+  /api/auth/apple/callback:
+    post:
+      tags: [auth]
+      summary: Apple OAuth callback
+      description: |
+        Handles the redirect from Apple (`response_mode: form_post`). On success,
+        creates or resumes a session and redirects to the SPA. Behaviour mirrors
+        the Google callback except the request method is POST.
+      requestBody:
+        required: true
+        content:
+          application/x-www-form-urlencoded:
+            schema:
+              type: object
+              properties:
+                code:
+                  type: string
+                id_token:
+                  type: string
+                state:
+                  type: string
+              additionalProperties: true
+      responses:
+        "302":
+          description: Redirect to SPA
+
+  /api/auth/facebook:
+    get:
+      tags: [auth]
+      summary: Initiate Facebook OAuth flow
+      description: Redirects to Facebook. Returns 400 if Facebook OAuth is not configured.
+      responses:
+        "302":
+          description: Redirect to Facebook authorization endpoint
+        "400":
+          $ref: "#/components/responses/BadRequest"
+
+  /api/auth/facebook/callback:
+    get:
+      tags: [auth]
+      summary: Facebook OAuth callback
+      description: Handles the redirect from Facebook. Behaviour mirrors the Google callback.
       responses:
         "302":
           description: Redirect to SPA

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -46,8 +46,9 @@ Health checks ensure `api` and `frontend` only start after `db` and `valkey` are
 
 **Production services** (`compose.prod.yaml`):
 - `db` and `valkey` — same images, restart: unless-stopped
-- `api` — `ghcr.io/luispabon/openfitlab-backend:latest`, 2 replicas, Traefik labels
-- `frontend` — `ghcr.io/luispabon/openfitlab-frontend:latest`, 2 replicas, Traefik labels
+- `api` — `ghcr.io/luispabon/openfitlab-backend:${OPENFITLAB_IMAGE_TAG:-main}` (default tag `main`), 2 replicas, Traefik labels
+- `frontend` — `ghcr.io/luispabon/openfitlab-frontend:${OPENFITLAB_IMAGE_TAG:-main}`, 2 replicas, Traefik labels
+- `backup` — optional (`profiles: backup`); scheduled DB dumps. `fake-gcs` / `fake-gcs-init` — optional (`profiles: dev-backup`) for local backup testing
 
 ### Dockerfiles
 
@@ -62,9 +63,9 @@ The prod stack uses two named networks:
 - `internal` — db, valkey, api (not exposed externally)
 - `dmz` — api, frontend (attached to an existing external network expected by Traefik)
 
-Traefik terminates TLS and routes:
-- `Host(${DOMAIN}) && PathPrefix(/api/)` → api
-- `Host(${DOMAIN})` → frontend
+Traefik terminates TLS and routes (see `compose.prod.yaml` labels; host is `${OPENFITLAB_DOMAIN:?...}`):
+- `Host(...)` + `PathPrefix(/api/)` → api
+- `Host(...)` (no path prefix) → frontend
 
 Both services are tagged for Watchtower auto-updates.
 
@@ -105,10 +106,10 @@ Reports are written to `./zap-reports/` (gitignored locally; uploaded as a GitHu
 
 `.env.example` is the canonical reference with inline documentation. Copy it to `.env` before starting the dev stack.
 
-Required in production only:
+Required in production only (names in `.env.example`; production compose may use `OPENFITLAB_*` prefixed vars — see `compose.prod.yaml`):
 - `SESSION_SECRET` — min 32 chars, generate with `openssl rand -hex 32`
 - `MARIADB_ROOT_PASSWORD`, `MARIADB_PASSWORD`
-- `OAUTH_CALLBACK_URL`, `DOMAIN`
+- `OAUTH_CALLBACK_URL` — public API base URL (no trailing slash); used for OAuth redirects
 
 Optional: OAuth credentials (`GOOGLE_CLIENT_ID/SECRET`, `GITHUB_CLIENT_ID/SECRET`, `APPLE_CLIENT_ID/TEAM_ID/KEY_ID/PRIVATE_KEY`, `FACEBOOK_APP_ID/APP_SECRET`), **Strava import** (`STRAVA_CLIENT_ID`, `STRAVA_CLIENT_SECRET` — both required to enable Strava; register redirect `{OAUTH_CALLBACK_URL}/api/integrations/strava/callback` in the Strava app), rate limit overrides, `VITE_GA_MEASUREMENT_ID` (GA4 Measurement ID; presence enables frontend analytics).
 
@@ -187,6 +188,8 @@ erDiagram
         varchar src_file_type
         varchar start_timezone
         varchar end_timezone
+        varchar import_provider
+        varchar import_external_id
         timestamp created_at
     }
 
@@ -253,7 +256,7 @@ erDiagram
 - Protected routes require a valid session and are scoped to the authenticated user.
 - Resource ownership is enforced with `req.userId`; request bodies do not decide ownership.
 - Missing or not-owned resources return `404`.
-- State-changing requests require `CSRF-Token` or `X-CSRF-Token`.
+- State-changing requests must include the CSRF token in a header (**CSRF-Token** as used by the SPA, or **x-csrf-token**; both accepted — value from `GET /api/auth/me`).
 - JSON responses use millisecond timestamps.
 - Error responses use `{ error: string }` with the appropriate HTTP status code.
 - Backend error classes (`ParseError`, `ValidationError`, `NotFoundError` in `backend/src/errors.js`) set `statusCode`; the central error handler maps it to the HTTP response.
@@ -381,60 +384,11 @@ Comparison responses include:
 
 ### Stream analysis (frontend-only)
 
-Stream analysis runs entirely client-side in `frontend/src/lib/utils/stream-analysis.ts`. No additional API endpoints are needed.
-
-Key functions:
-
-- `alignStreams` — nearest-neighbour alignment of two streams by elapsed time; pairs with gap > 30 s are excluded
-- `buildDeltaSeries` — builds a secondary − reference delta series indexed by elapsed ms
-- `computePearson` — Pearson correlation coefficient
-- `computeLinearRegression` — OLS slope, intercept, and R²
-- `computeStreamAnalysisStats` — aggregated stats (r, r2, slope, intercept, n, meanDiff, maxAbsDiff)
-
-UI components:
-
-- `ScatterChart.svelte` — uPlot XY scatter with optional regression line overlay
-- `DeltaChart.svelte` — uPlot area chart of delta over elapsed time with a zero-baseline dashed line
-- `StreamAnalysisSection.svelte` — orchestrates stream selection, alignment, and chart/stats display for each secondary-vs-reference pair
-- `StreamAnalysisCard.svelte` — renders a single reference-vs-secondary pair card (scatter chart, delta chart, stats row) with a per-card export button
+Stream analysis (alignment, scatter, regression, delta series) runs entirely client-side in `frontend/src/lib/utils/stream-analysis.ts` and related comparison-view components. No API endpoints.
 
 ### Image export (frontend-only)
 
-Users can export sections of the comparison view as PNG files. Export runs entirely
-client-side using `html-to-image`. No API endpoints are involved.
-
-Key utility:
-
-- `export-image.ts` — `exportAsPng(element, filename)`: captures a DOM element (including
-  any embedded `<canvas>`) to a retina-quality PNG and triggers a browser download.
-  - **Background:** uses the `--color-surface-solid` CSS custom property (the opaque dark
-    surface colour) so that the semi-transparent `bg-card` / `bg-surface` values don't
-    produce transparent PNGs when composited without a parent background.
-  - **Filter:** elements with `data-export-exclude` are stripped from the capture so UI
-    controls (e.g. `ExportButton` itself) never appear in the exported image.
-
-Exported sections:
-
-| Section | Trigger | Element captured |
-|---|---|---|
-| Stats table | Button in table header | Outer card div of `ComparisonStatsTable` |
-| Map | Button in map overlay controls | 600 px map container div (includes legend and nav controls) |
-| Stream comparison chart | Button per chart card | `ComparisonChartCard` root div (title + uPlot canvas) |
-| Stream analysis box | Button per pair card | `StreamAnalysisCard` root div (scatter + delta charts + stats row) |
-
-MapLibre requires `preserveDrawingBuffer: true` on the `Map` constructor for the WebGL
-framebuffer to remain readable after each frame. This option is set on the `<MapLibre>`
-component in `RouteMap.svelte`.
-
-Hidden stats rows are naturally excluded from exports because `allStatTypes` is filtered
-by `hiddenStats` before being passed to `ComparisonStatsTable`, so hidden rows are never
-in the DOM.
-
-Reusable component:
-
-- `ExportButton.svelte` — small icon button wrapping an `onExport: () => Promise<void>`
-  callback; disables itself while the export is in-flight to prevent double-clicks. Carries
-  `data-export-exclude` so the button is never included in the captured image.
+Users can export sections of the comparison view as PNG files using client-side DOM capture (`frontend/src/lib/utils/export-image.ts`, `html-to-image`). No API endpoints. Elements marked `data-export-exclude` are omitted from captures (e.g. export controls). Map exports require WebGL readback support where the map component enables it.
 
 ### File export (TCX/GPX)
 
@@ -442,27 +396,22 @@ Users can download activity data reconstructed from stored event, activity, stat
 stream data. The original uploaded file is discarded after processing; exports are a
 best-effort reconstruction from what was stored.
 
-Key backend modules:
+**Behaviour**
 
-- `backend/src/services/export-service.js`: `exportEventAsTcx(eventId, opts)` and
-  `exportEventAsGpx(eventId, opts)` — fetch relational data and delegate to builders.
-- `backend/src/utils/tcx-builder.js`: `buildTcx(event, activities, statsByActivityId,
-  streamsByActivityId)` — produces TCX 2.0 XML with one `<Lap>` per activity.
-- `backend/src/utils/gpx-builder.js`: `buildGpx(event, activities, streamsByActivityId)`
-  — produces GPX 1.1 XML with one `<trkseg>` per activity; returns `null` when no GPS
-  streams are present.
-- `backend/src/utils/trackpoint-builder.js`: `buildTrackpoints(streamMap)` — merges all
-  stream types onto a common timestamp grid using binary-search nearest-neighbour
-  resolution (30-second tolerance).
+- TCX: TCX 2.0 with one `<Lap>` per activity; lap summaries use stored activity stats (time, distance, max speed, calories, heart rate where available); device name in `<Creator>` when stored; sport type mapped from stored activity type.
+- GPX: GPX 1.1 with one `<trkseg>` per activity when GPS streams exist (Latitude/Longitude or Position); extensions include heart rate, cadence, power, temperature where stored; `buildGpx` returns `null` when no GPS streams.
+- Trackpoints: union of stream timestamps; each stream value resolved by nearest-neighbour lookup (30-second tolerance in `trackpoint-builder.js`).
+- Multi-activity events: single download file (multiple laps / track segments).
+- Filenames derive from the event name.
 
-Key frontend modules:
+**Implementation**
 
-- `frontend/src/lib/api/export.ts`: `downloadEventTcx` and `downloadEventGpx` — fetch
-  from the export endpoints and trigger browser downloads via blob URL.
-- `frontend/src/lib/components/EventExportDropdown.svelte` — dropdown in the event detail
-  header offering TCX (always) and GPX (only when the event has GPS streams). Carries
-  `data-export-exclude` so it is omitted from PNG exports. Always shows the notice that
-  exports are reconstructed from stored data.
+- `backend/src/services/export-service.js`: `exportEventAsTcx`, `exportEventAsGpx`.
+- `backend/src/utils/tcx-builder.js`, `backend/src/utils/gpx-builder.js`, `backend/src/utils/trackpoint-builder.js`.
+- `frontend/src/lib/api/export.ts`: `downloadEventTcx`, `downloadEventGpx`.
+- `frontend/src/lib/components/EventExportDropdown.svelte`: event detail export dropdown; always shows that exports are reconstructed from stored data.
+
+FIT export is not implemented (no maintained Node FIT writer suitable for this stack at time of writing).
 
 ### Meta
 

--- a/docs/INTEGRATIONS_INSTRUCTIONS.md
+++ b/docs/INTEGRATIONS_INSTRUCTIONS.md
@@ -134,3 +134,10 @@ STRAVA_CLIENT_SECRET=your-client-secret
 ```
 
 After restarting the API, `GET /api/auth/me` reports `integrations.providers.strava.configured: true` and the Workouts page shows **Import from…**. Strava access tokens are stored in the session (Valkey), not in the database. See [docs/ARCHITECTURE.md](docs/ARCHITECTURE.md) (Strava import) for behavior details.
+
+### Strava — product and compliance
+
+- **v1:** Strava access tokens are **not** persisted in MariaDB; they live in the Valkey-backed session until expiry, then the user reconnects.
+- **Deduplication:** the same Strava activity must not appear twice; the UI indicates already-imported items. Deleting the local event allows importing again.
+- **Branding:** follow [Strava’s API agreement](https://www.strava.com/legal/api) and [developer brand guidelines](https://developers.strava.com/guidelines/) for connection UI and “View on Strava” links.
+- **Out of scope:** automatic/background sync; social features beyond reading the user’s own activities.

--- a/docs/PRD.md
+++ b/docs/PRD.md
@@ -198,43 +198,28 @@ Users can download activity data reconstructed from stored event, activity, stat
 
 Requirements:
 
-- provide a TCX export for every event, containing all stored stream data (heart rate, cadence, speed, power, altitude, distance, temperature, and GPS position where available)
-- provide a GPX export only when the event contains GPS streams (Latitude + Longitude or Position); includes route, elevation, and all supported extensions (heart rate, cadence, power, temperature)
-- multi-activity events produce a single file: one `<Lap>` per activity in TCX, one `<trkseg>` per activity in GPX
-- sport type is mapped from the stored activity type to the appropriate TCX or GPX value
-- device name is included in the TCX `<Creator>` element where stored
-- activity stats (total time, distance, max speed, calories, average and max heart rate) populate the TCX lap summary fields
-- trackpoints are built from the union of all stream timestamps; each stream value is resolved by nearest-neighbour lookup for that timestamp
-- exported files are named after the event name
-- the UI makes clear that exports are reconstructed from stored data and the original file was not retained; this notice is always visible near the export controls, not a modal blocker
-- export controls appear in the event detail view, top-right, at the same level as the "Back to Workouts" button, as a dropdown offering the available formats
-- the GPX option in the dropdown is only shown when the event has GPS streams
-- FIT export was considered and deferred: no viable Node.js FIT write library exists at the time of writing; the format's binary complexity and scale/offset requirements make a correct implementation impractical without a quality maintained library
+- TCX available for every event; GPX only when GPS streams exist
+- UI explains that exports are reconstructed from stored data (notice always visible near export controls, not a modal blocker)
+- export controls on event detail: dropdown (top-right, same level as back navigation) with TCX always and GPX when applicable
+- FIT export out of scope until a suitable maintained writer exists
 
-API:
-
-- `GET /api/events/:id/export/tcx` — returns a TCX file download; 404 if event is not found or not owned
-- `GET /api/events/:id/export/gpx` — returns a GPX file download; 404 if event is not found, not owned, or has no GPS streams
+API and file format behaviour: [docs/ARCHITECTURE.md](ARCHITECTURE.md) (File export).
 
 ### 3.10 Third-party platform import
 
 **Status:** Implemented (Strava v1)
 
-Users can pull activities from supported fitness platforms into OpenFitLab so they do not have to export files manually. **v1 ships with Strava** (OAuth, Workouts **Import from…** modal, deduplication, same relational model as uploads, **View on Strava** on event detail). **Polar Flow**, **Fitbit**, and similar services remain candidates for later releases.
+Users can pull activities from supported fitness platforms so they do not have to export files manually. **v1 is Strava** (OAuth, Workouts **Import from…**, deduplication, same relational model as uploads, **View on Strava** on event detail). Other providers are candidates for later releases.
 
 **Requirements**
 
-- Imported workouts use the **same underlying data model** as file uploads (events, activities, stats, streams).
-- Integration is **operator-configured** (e.g. API credentials). If nothing is configured, users see **no** import entry point.
-- The user **connects** a platform (standard OAuth-style consent), **browses** their activities, and **chooses** what to import. On **Workouts**, **Import from…** opens a flow that can switch between supported providers as more are added.
-- The same activity from a provider **must not** appear twice in the user’s library; the UI should make already-imported items obvious. **Deleting** the event in OpenFitLab **allows** importing that activity again.
-- **v1** does **not** persist provider refresh tokens or access tokens in MariaDB: the Strava access token lives in the Valkey-backed session until expiry, then the user **reconnects** (see `docs/ARCHITECTURE.md`).
-- Use of Strava must follow **Strava’s API agreement and branding rules** (including how connection and “view on Strava” links are presented).
+- Same data model as file uploads (events, activities, stats, streams).
+- Operator-configured credentials; if not configured, no import entry point.
+- User connects, browses, and chooses imports; no automatic background sync.
+- No duplicate imports for the same provider activity; deleting the local event allows re-import.
+- Strava branding and API terms must be respected.
 
-**Out of scope**
-
-- **Automatic or background sync** (import is always something the user explicitly starts).
-- Treating third-party platforms as social features beyond what is needed to read the user’s own activities.
+Operator setup and technical behaviour: [docs/INTEGRATIONS_INSTRUCTIONS.md](INTEGRATIONS_INSTRUCTIONS.md) and [docs/ARCHITECTURE.md](ARCHITECTURE.md) (Strava import).
 
 ### 3.11 Single-user passphrase mode
 
@@ -291,12 +276,12 @@ For personal deployments where configuring an OAuth2 provider is impractical, a 
 - users can review workouts in a dashboard
 - users can inspect workout metrics visually
 - users can compare activities side-by-side
+- users can analyze stream correlations (comparison view stream analysis)
+- users can compare trackers effectively (via multi-device imports and comparison)
 - when the operator configures Strava, users can import activities from Strava without duplicate events for the same source activity (until they delete the local event)
 
 ### 6.2 Future success criteria
 
-- users can analyze stream correlations
-- users can compare trackers effectively
 - the product remains usable with large personal histories
 
 ---
@@ -330,29 +315,13 @@ For personal deployments where configuring an OAuth2 provider is impractical, a 
 
 - integration and end-to-end testing
 
+**Backend integration tests** (real MariaDB via `testcontainers-node`, separate CI job): transaction correctness; cascade deletes; schema constraints; OAuth pending-signup → complete-signup flow.
+
+**End-to-end tests** (Playwright, Docker Compose): **Implemented** — `e2e/tests/`, on every PR to `main` (`.github/workflows/e2e-checks.yml`). Covers upload → dashboard → event detail → comparison; folders; account export/delete; CSRF and auth; deletes. Dedicated stack: API `3098`, DB `3308`, Frontend `4201`.
+
 ### Phase 6 (future)
 
 - site activity reporting and optional admin or metrics dashboard
-
-Backend integration tests (real MariaDB container via `testcontainers-node`, separate CI job):
-
-- transaction correctness: multi-statement writes either fully commit or fully roll back
-- cascade deletes: deleting a user or event removes all child rows
-- schema constraint enforcement: duplicate identity provider rows are rejected at the DB level
-- OAuth session flow: pending signup → complete signup creates exactly one user and one identity
-
-Frontend + backend end-to-end tests (Playwright against the Docker Compose stack):
-
-**Status:** Implemented. Tests live in `e2e/tests/` and run on every PR targeting `main` via `.github/workflows/e2e-checks.yml`.
-
-Covered flows:
-- full upload → dashboard → event detail → comparison flow
-- folder create, assign, filter, and delete
-- account export and account delete
-- CSRF protection, unauthenticated access, and not-found handling
-- event and comparison deletion, including cascade cleanup
-
-CI integration: runs as a separate `e2e` job, not blocking the fast unit-test pipeline. Uses a dedicated Docker Compose stack on ports API `3098`, DB `3308`, Frontend `4201`.
 
 ---
 

--- a/docs/integrations/strava-stage1-notes.md
+++ b/docs/integrations/strava-stage1-notes.md
@@ -1,8 +1,8 @@
 # Strava integration — Stage 1 verification notes
 
-Operator checklist before production (see also [Strava API Agreement](https://www.strava.com/legal/api) and [brand guidelines](https://developers.strava.com/guidelines/)):
+Operator checklist before production (see also [Strava API Agreement](https://www.strava.com/legal/api) and [brand guidelines](https://developers.strava.com/guidelines/)). **Redirect URI:** register the exact URI from [docs/INTEGRATIONS_INSTRUCTIONS.md](../INTEGRATIONS_INSTRUCTIONS.md) (Strava activity import).
 
-- [ ] Register redirect URI in the Strava app (exact match, including `https` and path): `{OAUTH_CALLBACK_URL}/api/integrations/strava/callback` (e.g. `http://localhost:3000/api/integrations/strava/callback` for local API).
+- [ ] Register that redirect URI in the Strava app (exact match, including scheme and path).
 - [ ] Decide one Strava app for dev+prod (same callback host) vs separate apps per environment; document in operator runbook.
 - [ ] OAuth authorize with `scope=activity:read_all`; confirm `GET /athlete/activities`, `GET /activities/{id}`, and `GET /activities/{id}/streams` succeed on at least one private activity.
 - [ ] If any required call returns 403, widen scope in the app settings and update the authorize URL in code.

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -1,10 +1,10 @@
 # OpenFitLab Frontend
 
-Svelte 5, Vite, Tailwind CSS v4, svelte-spa-router. Run: `npm run dev`. Build: `npm run build`; preview: `npm run preview`. The app uses `/api` for the backend (proxied in dev, same-origin in production).
+Svelte 5, Vite, Tailwind CSS v4, svelte-spa-router. The app calls `/api` (proxied in dev, same-origin in production).
 
-**How it works:** Workouts lists activities via GET /api/events/activity-rows (filters, pagination). Event detail loads the event (GET /api/events/:id) then streams for the selected activity (GET .../streams). Comparisons list and comparison view use the comparisons API; see [docs/ARCHITECTURE.md](../docs/ARCHITECTURE.md) for route → API usage. When the backend reports Strava as configured (`GET /api/auth/me` → `integrations.providers.strava.configured`), Workouts shows **Import from…** and uses `frontend/src/lib/api/strava.ts` for list/import calls.
+**Data flow:** Workouts use `/api/events/activity-rows`; event detail uses `/api/events/:id` and stream endpoints; comparisons use the comparisons API. Strava list/import when `GET /api/auth/me` reports `integrations.providers.strava.configured`. Details: [docs/ARCHITECTURE.md](../docs/ARCHITECTURE.md).
 
-**Quality gate and testing:** Run `npm run format`, `npm run lint`, `npm run check`, `npm run test`, and `npm run build` from `frontend/`. Single command for all checks: `npm run ci`. Tests use Vitest; unit and API tests live in `__tests__/` next to modules, fixtures in `src/test/fixtures/`. See [.cursor/rules/frontend-lint-test.mdc](../.cursor/rules/frontend-lint-test.mdc) for conventions.
+**Commands and quality gate:** [AGENTS.md](../AGENTS.md) (`npm run ci`). Conventions: [.cursor/rules/frontend-lint-test.mdc](../.cursor/rules/frontend-lint-test.mdc), [.cursor/rules/svelte-frontend.mdc](../.cursor/rules/svelte-frontend.mdc).
 
 **Google Analytics (optional):** Set `VITE_GA_MEASUREMENT_ID=G-XXXXXXXXXX` at build time to enable GA4 tracking. Omit the variable (or leave it blank) to disable analytics entirely — no script is injected and no data is sent.
 
@@ -17,4 +17,3 @@ To get a Measurement ID:
 
 The app respects the browser's Do Not Track signal and a per-user opt-out stored in `localStorage`. Page views are tracked automatically on every SPA route change. No advertising features or Google Signals are enabled.
 
-See root [AGENTS.md](../AGENTS.md) for stack and [.cursor/rules/svelte-frontend.mdc](../.cursor/rules/svelte-frontend.mdc) for conventions.


### PR DESCRIPTION
## Summary

Documentation pass aligned with the documentation full-review plan: fix inaccuracies, reduce duplication, and standardise terminology.

## Changes

* **README:** Remove broken `docs/HOSTING.md` references; shorter architecture/API sections; canonical backend checks (`npm run test`); prerequisites Node 20+/24+; fix `compose.yaml` filename.
* **OpenAPI:** List all OAuth entrypoints; add Apple and Facebook auth paths; document CSRF headers (`CSRF-Token` and `x-csrf-token`).
* **ARCHITECTURE:** ERD adds import columns; production compose (`OPENFITLAB_IMAGE_TAG`, optional backup/fake-gcs); Traefik/env fixes; condensed stream analysis / image export; expanded file-export behaviour section.
* **PRD:** Success criteria and roadmap structure fixes; shorter §3.9/§3.10 with pointers to technical docs.
* **INTEGRATIONS:** Strava product/compliance subsection.
* **AGENTS / READMEs / strava-stage1-notes:** Slim invariants, less command duplication, cross-links for Strava redirect URI.

## Testing

Documentation-only; no runtime code changes.

Made with [Cursor](https://cursor.com)